### PR TITLE
Implement cache directory utilities needed for jobState

### DIFF
--- a/__mocks__/fs.ts
+++ b/__mocks__/fs.ts
@@ -1,0 +1,2 @@
+import { fs } from 'memfs';
+export const promises = fs.promises;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typescript": "^3.8.3"
   },
   "jest": {
+    "clearMocks": true,
     "preset": "ts-jest",
     "testPathIgnorePatterns": [
       "<rootDir>/dist/",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "prepublishOnly": "tsc --declaration"
   },
   "devDependencies": {
+    "@types/jest": "^25.2.1",
     "@types/node": "^13.11.0",
+    "@types/uuid": "^7.0.2",
     "@typescript-eslint/eslint-plugin": "^2.26.0",
     "@typescript-eslint/parser": "^2.26.0",
     "eslint": "^6.8.0",
@@ -27,6 +29,7 @@
     "husky": "^4.2.3",
     "jest": "^25.2.6",
     "lint-staged": "^10.1.1",
+    "memfs": "^3.1.2",
     "prettier": "^2.0.2",
     "ts-jest": "^25.3.0",
     "typescript": "^3.8.3"
@@ -80,7 +83,9 @@
     "*.{js,jsx,ts,tsx,md,html,css}": "prettier --write"
   },
   "dependencies": {
+    "@types/lodash": "^4.14.149",
     "eslint-config-prettier": "^6.10.1",
-    "eslint-plugin-prettier": "^3.1.2"
+    "eslint-plugin-prettier": "^3.1.2",
+    "uuid": "^7.0.3"
   }
 }

--- a/src/__tests__/cacheDirectory.test.ts
+++ b/src/__tests__/cacheDirectory.test.ts
@@ -1,0 +1,176 @@
+import { promises as fs } from 'fs';
+import { v4 as uuid } from 'uuid';
+import { vol } from 'memfs';
+
+import {
+  getDefaultCacheDirectory,
+  writeJsonToPath,
+  symlink,
+} from '../cacheDirectory';
+
+jest.mock('fs'); // applies manual mock which uses memfs
+
+afterEach(() => {
+  jest.clearAllMocks();
+  vol.reset(); // clear out memory
+});
+
+describe('getDefaultCacheDirectory', () => {
+  test('should utilize the current directory for building the default cache directory', () => {
+    const mockCwdResult = `/${uuid()}`;
+    jest.spyOn(process, 'cwd').mockReturnValue(mockCwdResult);
+
+    expect(getDefaultCacheDirectory()).toEqual(
+      `${mockCwdResult}/.j1-integration`,
+    );
+  });
+});
+
+describe('writeJsonToPath', () => {
+  test('should pretty write json to the specified file', async () => {
+    const json = { test: '123' };
+
+    const directory = '/';
+    const filename = `${uuid()}.json`;
+
+    await writeJsonToPath({
+      cacheDirectory: directory,
+      path: filename,
+      data: json,
+    });
+
+    const writtenData = await fs.readFile(`${directory}/${filename}`, 'utf8');
+    expect(writtenData).toEqual(JSON.stringify(json, null, 2));
+  });
+
+  test('should recursively create directories prior to writing', async () => {
+    const json = { woah: 'json' };
+
+    const directory = '/';
+    const filename = `test/dir/that/does/not/already/exist/${uuid()}.json`;
+
+    const mkdirSpy = jest.spyOn(fs, 'mkdir');
+    const writeFileSpy = jest.spyOn(fs, 'writeFile');
+
+    await writeJsonToPath({
+      cacheDirectory: directory,
+      path: filename,
+      data: json,
+    });
+
+    const writtenData = await fs.readFile(`${directory}/${filename}`, 'utf8');
+    expect(writtenData).toEqual(JSON.stringify(json, null, 2));
+
+    expect(mkdirSpy).toHaveBeenCalledTimes(1);
+    expect(mkdirSpy).toHaveBeenCalledWith(
+      '/test/dir/that/does/not/already/exist',
+      {
+        recursive: true,
+      },
+    );
+
+    // not pretty but wanted to enforce that mkdir was being called before
+    // write file
+    //
+    // ref: https://github.com/facebook/jest/issues/4402#issuecomment-534516219
+    const mkdirOrder = mkdirSpy.mock.invocationCallOrder[0];
+    const writeFileOrder = writeFileSpy.mock.invocationCallOrder[0];
+    expect(mkdirOrder).toBeLessThan(writeFileOrder);
+  });
+
+  test('should default to fetching default cache directory if option is not supplied', async () => {
+    const json = { tiger: 'king' };
+
+    const filename = `${uuid()}.json`;
+
+    await writeJsonToPath({
+      path: filename,
+      data: json,
+    });
+
+    const expectedFilePath = `${getDefaultCacheDirectory()}/${filename}`;
+
+    const volData = vol.toJSON();
+    expect(volData).toEqual({
+      [expectedFilePath]: JSON.stringify(json, null, 2),
+    });
+  });
+});
+
+describe('symlink', () => {
+  test('should create symlink from source path to destination path', async () => {
+    const sourcePath = 'test.json';
+    const destinationPath = 'symlink.json';
+
+    const jsonString = JSON.stringify({ testing: 100000 }, null, 2);
+
+    await fs.writeFile(`/${sourcePath}`, jsonString);
+
+    await symlink({
+      cacheDirectory: '/',
+      sourcePath,
+      destinationPath,
+    });
+
+    expect(vol.toJSON()).toEqual({
+      // memfs only shows real files with toJSON
+      [`/${sourcePath}`]: jsonString,
+    });
+
+    const expectedDestination = `/${destinationPath}`;
+    const symlinkedData = await fs.readFile(expectedDestination, 'utf8');
+    expect(symlinkedData).toEqual(jsonString);
+
+    const stats = await fs.lstat(expectedDestination);
+    expect(stats.isSymbolicLink()).toEqual(true);
+  });
+
+  test('should recursively create directories prior to symlinking', async () => {
+    const jsonString = JSON.stringify({ over: 9000 }, null, 2);
+
+    const sourcePath = 'test.json';
+    const destinationPath = 'dir/that/does/not/exist/symlink.json';
+
+    const mkdirSpy = jest.spyOn(fs, 'mkdir');
+    const symlinkSpy = jest.spyOn(fs, 'symlink');
+
+    await fs.writeFile(`/${sourcePath}`, jsonString);
+
+    await symlink({
+      cacheDirectory: '/',
+      sourcePath,
+      destinationPath,
+    });
+
+    expect(mkdirSpy).toHaveBeenCalledTimes(1);
+    expect(mkdirSpy).toHaveBeenCalledWith('/dir/that/does/not/exist', {
+      recursive: true,
+    });
+
+    // same as one of the above tests,
+    // wanted to ensure mkdir was called prior to symlink
+    //
+    // ref: https://github.com/facebook/jest/issues/4402#issuecomment-534516219
+    const mkdirOrder = mkdirSpy.mock.invocationCallOrder[0];
+    const symlinkOrder = symlinkSpy.mock.invocationCallOrder[0];
+    expect(mkdirOrder).toBeLessThan(symlinkOrder);
+  });
+
+  test('should default to fetching default cache directory if option is not supplied', async () => {
+    const sourcePath = 'test.json';
+    const destinationPath = 'dir/that/does/not/exist/symlink.json';
+
+    const jsonString = JSON.stringify({ mochi: 'soba' }, null, 2);
+    await fs.writeFile(`/${sourcePath}`, jsonString);
+
+    await symlink({
+      sourcePath,
+      destinationPath,
+    });
+
+    const expectedFilePath = `${getDefaultCacheDirectory()}/${destinationPath}`;
+
+    const stats = await fs.lstat(expectedFilePath);
+    expect(stats.isSymbolicLink()).toEqual(true);
+  });
+});

--- a/src/__tests__/cacheDirectory.test.ts
+++ b/src/__tests__/cacheDirectory.test.ts
@@ -11,8 +11,7 @@ import {
 jest.mock('fs'); // applies manual mock which uses memfs
 
 afterEach(() => {
-  jest.clearAllMocks();
-  vol.reset(); // clear out memory
+  vol.reset(); // clear out file system
 });
 
 describe('getDefaultCacheDirectory', () => {

--- a/src/cacheDirectory.ts
+++ b/src/cacheDirectory.ts
@@ -1,0 +1,54 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export const DEFAULT_CACHE_DIRECTORY_NAME = '.j1-integration';
+
+export function getDefaultCacheDirectory() {
+  return path.resolve(process.cwd(), DEFAULT_CACHE_DIRECTORY_NAME);
+}
+
+interface WriteDataToPathInput {
+  cacheDirectory?: string;
+  path: string;
+  data: object;
+}
+
+/**
+ * Helper function for writing arbirary data to a path
+ * relative to the cache directory
+ */
+export async function writeJsonToPath({
+  cacheDirectory,
+  path: relativePath,
+  data,
+}: WriteDataToPathInput) {
+  const directory = cacheDirectory ?? getDefaultCacheDirectory();
+  const fullPath = path.resolve(directory, relativePath);
+
+  await ensurePathCanBeWrittenTo(fullPath);
+  await fs.writeFile(fullPath, JSON.stringify(data, null, 2), 'utf8');
+}
+
+interface SymlinkInput {
+  cacheDirectory?: string;
+  sourcePath: string;
+  destinationPath: string;
+}
+
+export async function symlink({
+  cacheDirectory,
+  sourcePath,
+  destinationPath,
+}: SymlinkInput) {
+  const directory = cacheDirectory ?? getDefaultCacheDirectory();
+  const fullSourcePath = path.resolve(directory, sourcePath);
+  const fullDestinationPath = path.resolve(directory, destinationPath);
+
+  await ensurePathCanBeWrittenTo(fullDestinationPath);
+  await fs.symlink(fullSourcePath, fullDestinationPath);
+}
+
+async function ensurePathCanBeWrittenTo(pathToWrite: string) {
+  const directoryPath = path.dirname(pathToWrite);
+  await fs.mkdir(directoryPath, { recursive: true });
+}

--- a/src/cacheDirectory.ts
+++ b/src/cacheDirectory.ts
@@ -14,8 +14,11 @@ interface WriteDataToPathInput {
 }
 
 /**
- * Helper function for writing arbirary data to a path
- * relative to the cache directory
+ * Function for writing arbirary data to a path
+ * relative to the cache directory.
+ *
+ * This will ensure that the directories exists or have been
+ * created prior to writing the file.
  */
 export async function writeJsonToPath({
   cacheDirectory,
@@ -35,6 +38,12 @@ interface SymlinkInput {
   destinationPath: string;
 }
 
+/**
+ * Function for creating a symlink from on file to another.
+ *
+ * This will ensure that the directories exists or have been
+ * created prior to writing the file.
+ */
 export async function symlink({
   cacheDirectory,
   sourcePath,

--- a/yarn.lock
+++ b/yarn.lock
@@ -464,10 +464,23 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^25.2.1":
+  version "25.2.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-25.2.1.tgz#9544cd438607955381c1bdbdb97767a249297db5"
+  integrity sha512-msra1bCaAeEdkSyA0CZ6gW1ukMIvZ5YoJkdXw/qhQdsuuDlFTcEUrUw8CLCPt2rVRUfXlClVvK2gvPs9IokZaA==
+  dependencies:
+    jest-diff "^25.2.1"
+    pretty-format "^25.2.1"
+
 "@types/json-schema@^7.0.3":
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
+
+"@types/lodash@^4.14.149":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
 
 "@types/node@^13.11.0":
   version "13.11.0"
@@ -488,6 +501,11 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/uuid@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-7.0.2.tgz#d680a9c596ef84abf5c4c07a32ffd66d582526f8"
+  integrity sha512-8Ly3zIPTnT0/8RCU6Kg/G3uTICf9sRwYOpUzSIM3503tLIKcnJPRuinHhXngJUy2MntrEf6dlpOHXJju90Qh5w==
 
 "@types/yargs-parser@*":
   version "15.0.0"
@@ -1665,6 +1683,11 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+fs-monkey@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.0.tgz#b1fe36b2d8a78463fd0b8fd1463b355952743bd0"
+  integrity sha512-nxkkzQ5Ga+ETriXxIof4TncyMSzrV9jFIF+kGN16nw5CiAdWAnG/2FgM7CHhRenW1EBiDx+r1tf/P78HGKCgnA==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -2243,7 +2266,7 @@ jest-config@^25.2.6:
     pretty-format "^25.2.6"
     realpath-native "^2.0.0"
 
-jest-diff@^25.2.6:
+jest-diff@^25.2.1, jest-diff@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-25.2.6.tgz#a6d70a9ab74507715ea1092ac513d1ab81c1b5e7"
   integrity sha512-KuadXImtRghTFga+/adnNrv9s61HudRMR7gVSbP35UKZdn4IK2/0N0PpGZIqtmllK9aUyye54I3nu28OYSnqOg==
@@ -2833,6 +2856,13 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+memfs@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.1.2.tgz#2bb51600dacec67ed35677b1185abb708b7d2ad6"
+  integrity sha512-YubKuE+RGSdpZcRq2Nih8HcHj3LrqndsDFNB9IFjrgwzdM4eq+fImlDMfNm/HdRhYRkLdUecHGIpdz+wyrqlDg==
+  dependencies:
+    fs-monkey "1.0.0"
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
@@ -3248,7 +3278,7 @@ prettier@^2.0.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
   integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
 
-pretty-format@^25.2.6:
+pretty-format@^25.2.1, pretty-format@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.2.6.tgz#542a1c418d019bbf1cca2e3620443bc1323cb8d7"
   integrity sha512-DEiWxLBaCHneffrIT4B+TpMvkV9RNvvJrd3lY9ew1CEQobDzEXmYT1mg0hJhljZty7kCc10z13ohOFAE8jrUDg==
@@ -4103,6 +4133,11 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
+  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.0"


### PR DESCRIPTION
This adds a `cacheDirectory` utility that will be shared by both the `jobState` and CLI. The goal of this util is to provide an interface for writing data relative to some specified directory (the cache directory). The two functions implemented are for writing data and will be used by the `jobState` as data is flushed. Additional functions to help with iterating through files will come as the `iterateEntities` and `iterateRelationship` functions are implemented.

Normally I would use library like `fs-extra` to assist with writing files (does `mkdir -p` for you) but now that node's built-in `fs` lib has much better promise support and a recursive option with `mkdir`, I decided `fs-extra` added little value. 

An additional benefit of sticking with regular `fs` is that we can use tools like [memfs](https://github.com/streamich/memfs) (kind of a successor to `memory-fs`) to execute tests against an in-memory file system which is fast, does quick clean up, and (imo) has a nice interface for setting up test scenarios.