### PR TITLE
Implement jobstate iterate functions

### DIFF
--- a/src/cacheDirectory.ts
+++ b/src/cacheDirectory.ts
@@ -57,6 +57,66 @@ export async function symlink({
   await fs.symlink(fullSourcePath, fullDestinationPath);
 }
 
+interface WalkDirectoryIterateeInput {
+  filePath: string;
+  data: string;
+}
+
+type WalkDirectoryIteratee = (
+  input: WalkDirectoryIterateeInput,
+) => Promise<void> | void;
+
+interface WalkDirectoryInput {
+  cacheDirectory?: string;
+  path: string;
+  iteratee: WalkDirectoryIteratee;
+}
+
+/**
+ * Function for recursively walking through a directory
+ * and reading the data from each file.
+ */
+export async function walkDirectory({
+  cacheDirectory,
+  path: relativePath,
+  iteratee,
+}: WalkDirectoryInput) {
+  const directory = cacheDirectory ?? getDefaultCacheDirectory();
+  const fullPath = path.resolve(directory, relativePath);
+
+  const files = await fs.readdir(fullPath);
+
+  const onFile = async (filePath: string) => {
+    const data = await fs.readFile(filePath, 'utf8');
+    await iteratee({ filePath, data });
+  };
+
+  const handleFilePath = async (filePath: string) => {
+    const stats = await fs.lstat(filePath);
+    if (stats.isDirectory()) {
+      // continue walking the directory
+      await walkDirectory({
+        cacheDirectory,
+        iteratee,
+        path: filePath,
+      });
+    } else if (stats.isFile()) {
+      // handle the file
+      await onFile(filePath);
+    } else if (stats.isSymbolicLink()) {
+      // resolve the symlink then reperform check
+      // to determine path resolves to a file or
+      // if we should continue recursing
+      const realPath = await fs.realpath(filePath);
+      await handleFilePath(realPath);
+    }
+  };
+
+  for (const file of files) {
+    await handleFilePath(path.resolve(fullPath, file));
+  }
+}
+
 async function ensurePathCanBeWrittenTo(pathToWrite: string) {
   const directoryPath = path.dirname(pathToWrite);
   await fs.mkdir(directoryPath, { recursive: true });

--- a/src/framework/jobState/FileSystemJobState/FileSystemJobState.ts
+++ b/src/framework/jobState/FileSystemJobState/FileSystemJobState.ts
@@ -50,12 +50,7 @@ export class FileSystemJobState implements JobState {
     filter: GraphObjectFilter,
     iteratee: GraphObjectIteratee<Entity>,
   ) {
-    const entitiesMatchingType = this.entities.filter(
-      (e) => e._type === filter._type,
-    );
-    for (const entity of entitiesMatchingType) {
-      await iteratee(entity);
-    }
+    await this.flushEntitiesToDisk();
 
     await iterateEntityTypeIndex({
       cacheDirectory: this.cacheDirectory,
@@ -68,12 +63,7 @@ export class FileSystemJobState implements JobState {
     filter: GraphObjectFilter,
     iteratee: GraphObjectIteratee<Relationship>,
   ) {
-    const relationshipsMatchingType = this.relationships.filter(
-      (r) => r._type === filter._type,
-    );
-    for (const relationship of relationshipsMatchingType) {
-      await iteratee(relationship);
-    }
+    await this.flushRelationshipsToDisk();
 
     await iterateRelationshipTypeIndex({
       cacheDirectory: this.cacheDirectory,

--- a/src/framework/jobState/FileSystemJobState/__tests__/FileSystemJobState.test.ts
+++ b/src/framework/jobState/FileSystemJobState/__tests__/FileSystemJobState.test.ts
@@ -148,7 +148,7 @@ describe('addRelationships', () => {
 });
 
 describe('iterateEntities', () => {
-  test('iterate through each entity stored in memory', async () => {
+  test('should flush buffered entities and iterate the entity "_type" index stored on disk', async () => {
     const { jobState } = setupLocalStepJobState();
 
     const matchingType = uuid();
@@ -166,69 +166,16 @@ describe('iterateEntities', () => {
     const collectEntity = (e: Entity) => {
       collectedEntities.push(e);
     };
+
     await jobState.iterateEntities({ _type: matchingType }, collectEntity);
-
-    expect(collectedEntities).toEqual(matchingEntities);
-  });
-
-  test('should iterate relationships stored on disk', async () => {
-    const { jobState } = setupLocalStepJobState();
-
-    const matchingType = uuid();
-
-    const nonMatchingEntities = times(25, () =>
-      generateEntity({ _type: uuid() }),
-    );
-    const matchingEntities = times(25, () =>
-      generateEntity({ _type: matchingType }),
-    );
-
-    await jobState.addEntities([...nonMatchingEntities, ...matchingEntities]);
-    await jobState.flush();
-
     expect(jobState.entities).toHaveLength(0);
-
-    const collectedEntities: Entity[] = [];
-    const collectEntity = (e: Entity) => {
-      collectedEntities.push(e);
-    };
-    await jobState.iterateEntities({ _type: matchingType }, collectEntity);
 
     expect(collectedEntities).toEqual(matchingEntities);
   });
 });
 
 describe('iterateRelationships', () => {
-  test('iterate through each entity stored in memory', async () => {
-    const { jobState } = setupLocalStepJobState();
-
-    const matchingType = uuid();
-
-    const nonMatchingRelationships = times(25, () =>
-      generateRelationship({ _type: uuid() }),
-    );
-    const matchingRelationships = times(25, () =>
-      generateRelationship({ _type: matchingType }),
-    );
-
-    await jobState.addRelationships([
-      ...nonMatchingRelationships,
-      ...matchingRelationships,
-    ]);
-
-    const collectedRelationships: Relationship[] = [];
-    const collectRelationship = (r: Relationship) => {
-      collectedRelationships.push(r);
-    };
-    await jobState.iterateRelationships(
-      { _type: matchingType },
-      collectRelationship,
-    );
-
-    expect(collectedRelationships).toEqual(matchingRelationships);
-  });
-
-  test('should iterate relationships stored on disk', async () => {
+  test('should flush buffered relationshipos and iterate the relationship "_type" index stored on disk', async () => {
     const { jobState } = setupLocalStepJobState();
 
     const matchingType = uuid();
@@ -246,16 +193,16 @@ describe('iterateRelationships', () => {
     ]);
     await jobState.flush();
 
-    expect(jobState.relationships).toHaveLength(0);
-
     const collectedRelationships: Relationship[] = [];
     const collectRelationship = (r: Relationship) => {
       collectedRelationships.push(r);
     };
+
     await jobState.iterateRelationships(
       { _type: matchingType },
       collectRelationship,
     );
+    expect(jobState.relationships).toHaveLength(0);
 
     expect(collectedRelationships).toEqual(matchingRelationships);
   });

--- a/src/framework/jobState/FileSystemJobState/__tests__/FileSystemJobState.test.ts
+++ b/src/framework/jobState/FileSystemJobState/__tests__/FileSystemJobState.test.ts
@@ -11,6 +11,8 @@ import {
 
 import { generateEntity, generateRelationship } from './util/graphObjects';
 
+import { Entity, Relationship } from '../../../types';
+
 jest.mock('fs');
 
 afterEach(() => {
@@ -142,6 +144,120 @@ describe('addRelationships', () => {
     // adding an additional relationship should trigger the flushing
     await jobState.addRelationships([generateRelationship()]);
     expect(flushRelationshipsSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('iterateEntities', () => {
+  test('iterate through each entity stored in memory', async () => {
+    const { jobState } = setupLocalStepJobState();
+
+    const matchingType = uuid();
+
+    const nonMatchingEntities = times(25, () =>
+      generateEntity({ _type: uuid() }),
+    );
+    const matchingEntities = times(25, () =>
+      generateEntity({ _type: matchingType }),
+    );
+
+    await jobState.addEntities([...nonMatchingEntities, ...matchingEntities]);
+
+    const collectedEntities: Entity[] = [];
+    const collectEntity = (e: Entity) => {
+      collectedEntities.push(e);
+    };
+    await jobState.iterateEntities({ _type: matchingType }, collectEntity);
+
+    expect(collectedEntities).toEqual(matchingEntities);
+  });
+
+  test('should iterate relationships stored on disk', async () => {
+    const { jobState } = setupLocalStepJobState();
+
+    const matchingType = uuid();
+
+    const nonMatchingEntities = times(25, () =>
+      generateEntity({ _type: uuid() }),
+    );
+    const matchingEntities = times(25, () =>
+      generateEntity({ _type: matchingType }),
+    );
+
+    await jobState.addEntities([...nonMatchingEntities, ...matchingEntities]);
+    await jobState.flush();
+
+    expect(jobState.entities).toHaveLength(0);
+
+    const collectedEntities: Entity[] = [];
+    const collectEntity = (e: Entity) => {
+      collectedEntities.push(e);
+    };
+    await jobState.iterateEntities({ _type: matchingType }, collectEntity);
+
+    expect(collectedEntities).toEqual(matchingEntities);
+  });
+});
+
+describe('iterateRelationships', () => {
+  test('iterate through each entity stored in memory', async () => {
+    const { jobState } = setupLocalStepJobState();
+
+    const matchingType = uuid();
+
+    const nonMatchingRelationships = times(25, () =>
+      generateRelationship({ _type: uuid() }),
+    );
+    const matchingRelationships = times(25, () =>
+      generateRelationship({ _type: matchingType }),
+    );
+
+    await jobState.addRelationships([
+      ...nonMatchingRelationships,
+      ...matchingRelationships,
+    ]);
+
+    const collectedRelationships: Relationship[] = [];
+    const collectRelationship = (r: Relationship) => {
+      collectedRelationships.push(r);
+    };
+    await jobState.iterateRelationships(
+      { _type: matchingType },
+      collectRelationship,
+    );
+
+    expect(collectedRelationships).toEqual(matchingRelationships);
+  });
+
+  test('should iterate relationships stored on disk', async () => {
+    const { jobState } = setupLocalStepJobState();
+
+    const matchingType = uuid();
+
+    const nonMatchingRelationships = times(25, () =>
+      generateRelationship({ _type: uuid() }),
+    );
+    const matchingRelationships = times(25, () =>
+      generateRelationship({ _type: matchingType }),
+    );
+
+    await jobState.addRelationships([
+      ...nonMatchingRelationships,
+      ...matchingRelationships,
+    ]);
+    await jobState.flush();
+
+    expect(jobState.relationships).toHaveLength(0);
+
+    const collectedRelationships: Relationship[] = [];
+    const collectRelationship = (r: Relationship) => {
+      collectedRelationships.push(r);
+    };
+    await jobState.iterateRelationships(
+      { _type: matchingType },
+      collectRelationship,
+    );
+
+    expect(collectedRelationships).toEqual(matchingRelationships);
   });
 });
 

--- a/src/framework/jobState/FileSystemJobState/flushDataToDisk.ts
+++ b/src/framework/jobState/FileSystemJobState/flushDataToDisk.ts
@@ -5,8 +5,11 @@ import groupBy from 'lodash/groupBy';
 import { writeJsonToPath, symlink } from '../../../cacheDirectory';
 
 import { Entity, Relationship } from '../../types';
-
-export type CollectionType = 'entities' | 'relationships';
+import {
+  CollectionType,
+  buildIndexFilePath,
+  buildStepCollectionFilePath,
+} from './path';
 
 interface FlushDataToDiskInput {
   cacheDirectory?: string;
@@ -35,12 +38,12 @@ export async function flushDataToDisk({
     Object.entries(groupedCollections),
     async ([type, collection]) => {
       const filename = generateJsonFilename();
-      const graphDataPath = buildStepDataPath({
+      const graphDataPath = buildStepCollectionFilePath({
         step,
         collectionType,
         filename,
       });
-      const indexPath = buildIndexPath({ type, collectionType, filename });
+      const indexPath = buildIndexFilePath({ type, collectionType, filename });
 
       await writeJsonToPath({
         cacheDirectory,
@@ -62,30 +65,4 @@ export async function flushDataToDisk({
 
 function generateJsonFilename() {
   return `${uuid()}.json`;
-}
-
-interface BuildStepDataPathInput {
-  step: string;
-  collectionType: CollectionType;
-  filename: string;
-}
-function buildStepDataPath({
-  step,
-  collectionType,
-  filename,
-}: BuildStepDataPathInput) {
-  return ['graph', step, collectionType, filename].join('/');
-}
-
-interface BuildIndexPathInput {
-  collectionType: CollectionType;
-  type: string;
-  filename: string;
-}
-function buildIndexPath({
-  collectionType,
-  type,
-  filename,
-}: BuildIndexPathInput) {
-  return ['index', collectionType, type, filename].join('/');
 }

--- a/src/framework/jobState/FileSystemJobState/indices.ts
+++ b/src/framework/jobState/FileSystemJobState/indices.ts
@@ -1,0 +1,89 @@
+import { Entity, Relationship } from '../../types';
+import { GraphObjectIteratee } from '../types';
+
+import {
+  walkDirectory,
+  WalkDirectoryIterateeInput,
+} from '../../../cacheDirectory';
+
+import { buildIndexDirectoryPath } from './path';
+
+interface IterateIndexInput<GraphObject> {
+  cacheDirectory?: string;
+  type: string;
+  iteratee: GraphObjectIteratee<GraphObject>;
+}
+
+export async function iterateEntityTypeIndex({
+  cacheDirectory,
+  type,
+  iteratee,
+}: IterateIndexInput<Entity>) {
+  const path = buildIndexDirectoryPath({
+    collectionType: 'entities',
+    type,
+  });
+
+  await walkDirectory({
+    cacheDirectory,
+    path,
+    iteratee: async (input) => {
+      const object = parseData(input);
+      if (isObjectFlushedEntityData(object)) {
+        for (const entity of object.entities) {
+          await iteratee(entity);
+        }
+      }
+    },
+  });
+}
+
+export async function iterateRelationshipTypeIndex({
+  cacheDirectory,
+  type,
+  iteratee,
+}: IterateIndexInput<Relationship>) {
+  const path = buildIndexDirectoryPath({
+    collectionType: 'relationships',
+    type,
+  });
+
+  await walkDirectory({
+    cacheDirectory,
+    path,
+    iteratee: async (input) => {
+      const object = parseData(input);
+      if (isObjectFlushedRelationshipData(object)) {
+        for (const relationship of object.relationships) {
+          await iteratee(relationship);
+        }
+      }
+    },
+  });
+}
+
+function parseData({ filePath, data }: WalkDirectoryIterateeInput): object {
+  try {
+    return JSON.parse(data);
+  } catch (err) {
+    throw new Error(`Failed to parse JSON in '${filePath}'`);
+  }
+}
+
+interface FlushedEntityData {
+  entities: Entity[];
+}
+
+function isObjectFlushedEntityData(object: any): object is FlushedEntityData {
+  return Array.isArray(object?.entities);
+}
+
+interface FlushedRelationshipData {
+  relationships: Relationship[];
+}
+
+function isObjectFlushedRelationshipData(
+  object: any,
+): object is FlushedRelationshipData {
+  return Array.isArray(object?.relationships);
+}

--- a/src/framework/jobState/FileSystemJobState/path.ts
+++ b/src/framework/jobState/FileSystemJobState/path.ts
@@ -1,0 +1,41 @@
+export type CollectionType = 'entities' | 'relationships';
+
+interface BuildStepCollectionFilePathInput {
+  step: string;
+  collectionType: CollectionType;
+  filename: string;
+}
+
+export function buildStepCollectionFilePath({
+  step,
+  collectionType,
+  filename,
+}: BuildStepCollectionFilePathInput) {
+  return ['graph', step, collectionType, filename].join('/');
+}
+
+interface BuildIndexFilePathInput extends BuildIndexDirectoryPathInput {
+  filename: string;
+}
+
+export function buildIndexFilePath({
+  collectionType,
+  type,
+  filename,
+}: BuildIndexFilePathInput) {
+  return [buildIndexDirectoryPath({ collectionType, type }), filename].join(
+    '/',
+  );
+}
+
+interface BuildIndexDirectoryPathInput {
+  collectionType: CollectionType;
+  type: string;
+}
+
+export function buildIndexDirectoryPath({
+  collectionType,
+  type,
+}: BuildIndexDirectoryPathInput) {
+  return ['index', collectionType, type].join('/');
+}


### PR DESCRIPTION
This PR implements the `iterateEntities` and `iterateRelationships` functions. I added a function for recursively walking a directory to read files and used that for implementing iterate functions. It's a bit overkill right now, but was quick to implement and will be needed when we start working on the synchronization command anyway.