### PR TITLE
Add basic integration logger

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@types/lodash": "^4.14.149",
+    "bunyan": "^1.8.12",
     "dependency-graph": "^0.9.0",
     "lodash": "^4.17.15",
     "p-map": "^4.0.0",
@@ -27,6 +28,7 @@
     "uuid": "^7.0.3"
   },
   "devDependencies": {
+    "@types/bunyan": "^1.8.6",
     "@types/jest": "^25.2.1",
     "@types/node": "^13.11.0",
     "@types/uuid": "^7.0.2",

--- a/src/framework/execution/__tests__/executeIntegration.test.ts
+++ b/src/framework/execution/__tests__/executeIntegration.test.ts
@@ -2,6 +2,8 @@ import { IntegrationExecutionContext } from '../types';
 import { executeIntegrationLocally } from '../executeIntegration';
 import { LOCAL_INTEGRATION_INSTANCE } from '../instance';
 
+import Logger from 'bunyan';
+
 test('should execute validator function if provided in config', async () => {
   const validate = jest.fn();
 
@@ -12,6 +14,7 @@ test('should execute validator function if provided in config', async () => {
 
   const expectedContext: IntegrationExecutionContext = {
     instance: LOCAL_INTEGRATION_INSTANCE,
+    logger: expect.any(jest.requireActual('bunyan')),
   };
 
   expect(validate).toHaveBeenCalledWith(expectedContext);

--- a/src/framework/execution/__tests__/executeIntegration.test.ts
+++ b/src/framework/execution/__tests__/executeIntegration.test.ts
@@ -2,8 +2,6 @@ import { IntegrationExecutionContext } from '../types';
 import { executeIntegrationLocally } from '../executeIntegration';
 import { LOCAL_INTEGRATION_INSTANCE } from '../instance';
 
-import Logger from 'bunyan';
-
 test('should execute validator function if provided in config', async () => {
   const validate = jest.fn();
 

--- a/src/framework/execution/__tests__/logger.test.ts
+++ b/src/framework/execution/__tests__/logger.test.ts
@@ -1,0 +1,168 @@
+import { createIntegrationLogger } from '../logger';
+import Logger from 'bunyan';
+import { IntegrationInvocationConfig } from '../types';
+
+const invocationConfig = {} as IntegrationInvocationConfig;
+const loggerName = 'integration-logger';
+
+describe('logger.trace', () => {
+  test('includes verbose: true for downstream verbose log pruning', () => {
+    const integrationLogger = createIntegrationLogger(
+      loggerName,
+      invocationConfig,
+    );
+    const stream = (integrationLogger as any).streams[0]
+      .stream as Logger.RingBuffer;
+
+    integrationLogger.trace();
+    expect(stream.records).toEqual([]);
+
+    integrationLogger.trace({ stuff: 'yo!' }, 'Me message');
+    integrationLogger.trace(Error('Yo!'), 'Me message');
+    integrationLogger.trace('formatit', 'Me message');
+
+    expect(stream.records).toEqual([
+      expect.objectContaining({
+        stuff: 'yo!',
+        verbose: true,
+        msg: 'Me message',
+      }),
+      expect.objectContaining({
+        err: expect.objectContaining({
+          message: 'Yo!',
+        }),
+        verbose: true,
+        msg: 'Me message',
+      }),
+      expect.objectContaining({
+        verbose: true,
+        msg: 'formatit Me message',
+      }),
+    ]);
+  });
+
+  test('logger.child.trace', () => {
+    const integrationLogger = createIntegrationLogger(
+      loggerName,
+      invocationConfig,
+    );
+    const childLogger = integrationLogger.child({
+      mostuff: 'smile',
+    });
+    const stream = (childLogger as any).streams[0].stream as Logger.RingBuffer;
+
+    integrationLogger.trace();
+    childLogger.trace();
+    expect(stream.records).toEqual([]);
+
+    integrationLogger.trace({ stuff: 'parents right?' }, 'Dad joke');
+    childLogger.trace({ stuff: 'yo!' }, 'Me message');
+    expect(stream.records).toEqual([
+      expect.objectContaining({
+        stuff: 'parents right?',
+        verbose: true,
+        msg: 'Dad joke',
+      }),
+      expect.objectContaining({
+        stuff: 'yo!',
+        mostuff: 'smile',
+        verbose: true,
+        msg: 'Me message',
+      }),
+    ]);
+    expect(stream.records[0].mostuff).toBeUndefined();
+  });
+});
+
+describe('createIntegrationLogger', () => {
+  let addSerializers: jest.Mock;
+
+  beforeEach(() => {
+    addSerializers = jest.fn();
+    jest.spyOn(Logger, 'createLogger').mockReturnValue(({
+      addSerializers,
+    } as unknown) as Logger);
+  });
+
+  test('installs expected properties', async () => {
+    createIntegrationLogger(loggerName, invocationConfig);
+
+    expect(Logger.createLogger).toHaveBeenCalledWith({
+      name: 'integration-logger',
+      level: 'info',
+      serializers: {
+        err: Logger.stdSerializers.err,
+      },
+    });
+  });
+
+  test('adds provided serializers', () => {
+    createIntegrationLogger(loggerName, invocationConfig, {});
+    expect(addSerializers).toHaveBeenLastCalledWith({});
+  });
+
+  describe('integrationInstanceConfig serializer', () => {
+    test('is a function', () => {
+      createIntegrationLogger(loggerName, invocationConfig);
+
+      expect(addSerializers).toHaveBeenNthCalledWith(1, {
+        integrationInstanceConfig: expect.any(Function),
+        instance: expect.any(Function),
+      });
+    });
+
+    test('handles undefined config', () => {
+      createIntegrationLogger(loggerName, invocationConfig);
+      const serializer = addSerializers.mock.calls[0][0]
+        .integrationInstanceConfig as Function;
+      expect(serializer(undefined)).toEqual(undefined);
+    });
+
+    test('handles null config', () => {
+      createIntegrationLogger(loggerName, invocationConfig);
+      const serializer = addSerializers.mock.calls[0][0]
+        .integrationInstanceConfig as Function;
+
+      expect(serializer(null)).toEqual(null);
+    });
+
+    test('masks everything when field metadata not provided', () => {
+      createIntegrationLogger(loggerName, invocationConfig);
+      const serializer = addSerializers.mock.calls[0][0]
+        .integrationInstanceConfig as Function;
+
+      expect(serializer({ anything: 'bob', everything: 'jane' })).toEqual({
+        anything: '***',
+        everything: '***',
+      });
+    });
+
+    test('shows unmasked data', () => {
+      createIntegrationLogger(loggerName, {
+        ...invocationConfig,
+        instanceConfigFields: {
+          masked: {
+            mask: true,
+          },
+          unmasked: {
+            mask: false,
+          },
+        },
+      });
+      const serializer = addSerializers.mock.calls[0][0]
+        .integrationInstanceConfig as Function;
+
+      expect(
+        serializer({
+          anything: 'bob',
+          masked: 'this is secret',
+          unmasked: 'this is clear',
+        }),
+      ).toEqual({
+        anything: '***',
+        masked: '****cret',
+        unmasked: 'this is clear',
+      });
+    });
+  });
+});

--- a/src/framework/execution/executeIntegration.ts
+++ b/src/framework/execution/executeIntegration.ts
@@ -3,6 +3,7 @@ import {
   IntegrationExecutionContext,
 } from './types';
 
+import { createIntegrationLogger } from './logger';
 import { createIntegrationInstanceForLocalExecution } from './instance';
 
 /**
@@ -10,7 +11,11 @@ import { createIntegrationInstanceForLocalExecution } from './instance';
  */
 export function executeIntegrationLocally(config: IntegrationInvocationConfig) {
   const instance = createIntegrationInstanceForLocalExecution(config);
-  const context: IntegrationExecutionContext = { instance };
+  const logger = createIntegrationLogger(instance.name, config);
+  const context: IntegrationExecutionContext = {
+    instance,
+    logger,
+  };
 
   return executeIntegration(context, config);
 }

--- a/src/framework/execution/logger.ts
+++ b/src/framework/execution/logger.ts
@@ -1,0 +1,105 @@
+import Logger from 'bunyan';
+
+import {
+  IntegrationLogger,
+  IntegrationInstance,
+  IntegrationInvocationConfig,
+  IntegrationInstanceConfigFieldMap,
+} from './types';
+
+/**
+ * Create a logger for the integration that will include invocation details and
+ * serializers common to all integrations.
+ */
+export function createIntegrationLogger(
+  integrationName: string,
+  invocationConfig: IntegrationInvocationConfig,
+  serializers?: Logger.Serializers,
+): IntegrationLogger {
+  const logger = Logger.createLogger({
+    name: integrationName,
+    level: (process.env.LOG_LEVEL || 'info') as Logger.LogLevel,
+    serializers: {
+      err: Logger.stdSerializers.err,
+    },
+  });
+
+  const serializeInstanceConfig = createInstanceConfigSerializer(
+    invocationConfig.instanceConfigFields,
+  );
+
+  logger.addSerializers({
+    integrationInstanceConfig: serializeInstanceConfig,
+    // since config is serializable from
+    instance: (instance: IntegrationInstance) => ({
+      ...instance,
+      config: instance.config
+        ? serializeInstanceConfig(instance.config)
+        : undefined,
+    }),
+  });
+
+  if (serializers) {
+    logger.addSerializers(serializers);
+  }
+
+  return instrumentVerboseTrace(logger);
+}
+
+function createInstanceConfigSerializer(
+  fields?: IntegrationInstanceConfigFieldMap,
+) {
+  return (config: any) => {
+    if (!config) {
+      return config;
+    } else {
+      const serialized: any = {};
+      for (const k of Object.keys(config)) {
+        const field = fields && fields[k];
+        if (field) {
+          serialized[k] = field.mask
+            ? `****${config[k].substr(-4)}`
+            : config[k];
+        } else {
+          serialized[k] = '***';
+        }
+      }
+      return serialized;
+    }
+  };
+}
+
+function instrumentVerboseTrace(logger: Logger): Logger {
+  const trace = logger.trace;
+  const child = logger.child;
+
+  Object.assign(logger, {
+    trace: (...params: any[]) => {
+      if (params.length === 0) {
+        return trace.apply(logger);
+      }
+
+      let additionalFields: Record<string, any> = {};
+      let remainingArgs: any[] = params;
+      if (params[0] instanceof Error) {
+        additionalFields = { err: params[0] };
+        remainingArgs = params.slice(1);
+      } else if (typeof params[0] === 'object') {
+        additionalFields = params[0];
+        remainingArgs = params.slice(1);
+      }
+
+      trace.apply(logger, [
+        { verbose: true, ...additionalFields },
+        ...remainingArgs,
+      ]);
+    },
+
+    child: (options: object = {}, simple?: boolean) => {
+      const c = child.apply(logger, [options, simple]);
+      return instrumentVerboseTrace(c);
+    },
+  });
+
+  return logger;
+}

--- a/src/framework/execution/types/context.ts
+++ b/src/framework/execution/types/context.ts
@@ -1,9 +1,11 @@
 import { JobState } from '../../jobState';
 
 import { IntegrationInstance } from './instance';
+import { IntegrationLogger } from './logger';
 
 export interface IntegrationExecutionContext {
   instance: IntegrationInstance;
+  logger: IntegrationLogger;
 }
 
 export interface IntegrationStepExecutionContext {

--- a/src/framework/execution/types/index.ts
+++ b/src/framework/execution/types/index.ts
@@ -3,3 +3,4 @@ export * from './step';
 export * from './config';
 export * from './validation';
 export * from './instance';
+export * from './logger';

--- a/src/framework/execution/types/logger.ts
+++ b/src/framework/execution/types/logger.ts
@@ -1,0 +1,17 @@
+interface LogFunction {
+  (...args: any[]): boolean | void;
+}
+
+interface ChildLogFunction {
+  (options: object): IntegrationLogger;
+}
+
+export interface IntegrationLogger {
+  trace: LogFunction;
+  debug: LogFunction;
+  info: LogFunction;
+  warn: LogFunction;
+  error: LogFunction;
+  fatal: LogFunction;
+  child: ChildLogFunction;
+}

--- a/testSetup.ts
+++ b/testSetup.ts
@@ -26,9 +26,5 @@ jest.mock('bunyan', () => {
 
   MockLogger.stdSerializers = Logger.stdSerializers;
 
-  if (process.env.ENABLE_LOGGING === 'true') {
-    return Logger;
-  } else {
-    return MockLogger;
-  }
+  return MockLogger;
 });

--- a/testSetup.ts
+++ b/testSetup.ts
@@ -1,1 +1,34 @@
 import 'jest-extended';
+
+jest.mock('bunyan', () => {
+  const Logger = jest.requireActual('bunyan');
+
+  const LOG_LEVELS = ['trace', 'debug', 'info', 'fatal', 'warn', 'error'];
+  for (const logLevel of LOG_LEVELS) {
+    jest.spyOn(Logger.prototype, logLevel);
+  }
+
+  function MockLogger(options: any) {
+    const ringbuffer = new Logger.RingBuffer({ limit: 100 });
+    options.streams = [
+      {
+        level: 'trace',
+        type: 'raw',
+        stream: ringbuffer,
+      },
+    ];
+    return new Logger(options);
+  }
+
+  MockLogger.createLogger = function (options: any) {
+    return new (MockLogger as any)(options);
+  };
+
+  MockLogger.stdSerializers = Logger.stdSerializers;
+
+  if (process.env.ENABLE_LOGGING === 'true') {
+    return Logger;
+  } else {
+    return MockLogger;
+  }
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -470,6 +470,13 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bunyan@^1.8.6":
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/@types/bunyan/-/bunyan-1.8.6.tgz#6527641cca30bedec5feb9ab527b7803b8000582"
+  integrity sha512-YiozPOOsS6bIuz31ilYqR5SlLif4TBWsousN2aCWLi5233nZSX19tFbcQUPdR7xJ8ypPyxkCGNxg0CIV5n9qxQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/color-name@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
@@ -517,6 +524,11 @@
   version "4.14.149"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
   integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
+"@types/node@*":
+  version "13.11.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.1.tgz#49a2a83df9d26daacead30d0ccc8762b128d53c7"
+  integrity sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==
 
 "@types/node@^13.11.0":
   version "13.11.0"
@@ -930,6 +942,16 @@ buffer-from@1.x, buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
 
+bunyan@^1.8.12:
+  version "1.8.12"
+  resolved "https://registry.yarnpkg.com/bunyan/-/bunyan-1.8.12.tgz#f150f0f6748abdd72aeae84f04403be2ef113797"
+  integrity sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=
+  optionalDependencies:
+    dtrace-provider "~0.8"
+    moment "^2.10.6"
+    mv "~2"
+    safe-json-stringify "~1"
+
 cache-base@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
@@ -1315,6 +1337,13 @@ domexception@^1.0.1:
   integrity sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==
   dependencies:
     webidl-conversions "^4.0.2"
+
+dtrace-provider@~0.8:
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.8.tgz#2996d5490c37e1347be263b423ed7b297fb0d97e"
+  integrity sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==
+  dependencies:
+    nan "^2.14.0"
 
 ecc-jsbn@~0.1.1:
   version "0.1.2"
@@ -1838,6 +1867,17 @@ glob-parent@^5.0.0:
   integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
   dependencies:
     is-glob "^4.0.1"
+
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
@@ -3072,7 +3112,7 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -3104,6 +3144,18 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mkdirp@~0.5.1:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+  dependencies:
+    minimist "^1.2.5"
+
+moment@^2.10.6:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -3118,6 +3170,20 @@ mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+mv@~2:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/mv/-/mv-2.1.1.tgz#ae6ce0d6f6d5e0a4f7d893798d03c1ea9559b6a2"
+  integrity sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=
+  dependencies:
+    mkdirp "~0.5.1"
+    ncp "~2.0.0"
+    rimraf "~2.4.0"
+
+nan@^2.14.0:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -3140,6 +3206,11 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+ncp@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -3688,6 +3759,13 @@ rimraf@^3.0.0:
   dependencies:
     glob "^7.1.3"
 
+rimraf@~2.4.0:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
+  integrity sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=
+  dependencies:
+    glob "^6.0.1"
+
 rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
@@ -3716,6 +3794,11 @@ safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-json-stringify@~1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz#356e44bc98f1f93ce45df14bcd7c01cda86e0afd"
+  integrity sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==
 
 safe-regex@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This PR mostly adopts the integration logger implementation that already existed in the managed integration sdk. 

I changed a few small things. For example, the creating a logger no longer requires an `INTEGRATION_NAME` environment variable to be supplied. I think we can fetch that from the integration definition during managed runs and provide a default value during local runs.

Note: this doesn't include any special handling of `logger.auth` or `logger.error` messages.