### PR TITLE
Make IntegrationStepExecutionContext extend IntegrationExecutionContext

### DIFF
--- a/src/framework/execution/dependencyGraph.ts
+++ b/src/framework/execution/dependencyGraph.ts
@@ -8,6 +8,7 @@ import {
   IntegrationStepResult,
   IntegrationStepResultStatus,
   IntegrationExecutionContext,
+  IntegrationStepExecutionContext,
 } from './types';
 
 /**
@@ -183,7 +184,7 @@ export function executeStepDependencyGraph(
 function buildStepContext(
   context: IntegrationExecutionContext,
   step: IntegrationStep,
-) {
+): IntegrationStepExecutionContext {
   const logger = context.logger.child({
     step: step.id,
     stepName: step.name,

--- a/src/framework/execution/types/context.ts
+++ b/src/framework/execution/types/context.ts
@@ -8,6 +8,7 @@ export interface IntegrationExecutionContext {
   logger: IntegrationLogger;
 }
 
-export interface IntegrationStepExecutionContext {
+export interface IntegrationStepExecutionContext
+  extends IntegrationExecutionContext {
   jobState: JobState;
 }

--- a/src/framework/execution/types/step.ts
+++ b/src/framework/execution/types/step.ts
@@ -1,4 +1,24 @@
-import { IntegrationStepExecutionContext } from './context';
+import {
+  IntegrationExecutionContext,
+  IntegrationStepExecutionContext,
+} from './context';
+
+export interface IntegrationStepStartState {
+  /**
+   * Indicates the step is disabled and should not be
+   * executed by the state machine.
+   */
+  disabled: boolean;
+}
+
+export type IntegrationStepStartStates = Record<
+  string,
+  IntegrationStepStartState
+>;
+
+export type DetermineStepStartStatesFunction = (
+  context: IntegrationExecutionContext,
+) => IntegrationStepStartStates;
 
 export enum IntegrationStepResultStatus {
   SUCCESS = 'success',


### PR DESCRIPTION
Small change. I realized that I forgot to have `IntegrationStepExecutionContext` extend the `IntegrationExecutionContext`. This change will make it so that typescript devs don't go crazy over not having access to the `logger` on the context when it really is there.