### PR TITLE
Adopt create integration entity util

### DIFF
--- a/__mocks__/fs.ts
+++ b/__mocks__/fs.ts
@@ -1,2 +1,4 @@
 import { fs } from 'memfs';
 export const promises = fs.promises;
+
+export const readdirSync = jest.requireActual('fs').readdirSync;

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "prepublishOnly": "tsc --declaration"
   },
   "dependencies": {
+    "@jupiterone/data-model": "^0.2.0",
     "bunyan": "^1.8.12",
     "dependency-graph": "^0.9.0",
     "lodash": "^4.17.15",

--- a/src/framework/data/__tests__/createIntegrationEntity.test.ts
+++ b/src/framework/data/__tests__/createIntegrationEntity.test.ts
@@ -224,21 +224,6 @@ describe('createIntegrationEntity', () => {
     ).toThrowError(/duplicate/i);
   });
 
-  test('assigning duplicate rawData is an error', () => {
-    const rawData = [
-      { name: 'another', rawData: 'anything' },
-      { name: 'another', rawData: 'another' },
-    ];
-    expect(() =>
-      createIntegrationEntity({
-        entityData: {
-          assign: { ...networkAssigns, _rawData: rawData },
-          source: networkSourceData,
-        },
-      }),
-    ).toThrowError(/duplicate/i);
-  });
-
   test('empty source is no rawData', () => {
     expect(
       createIntegrationEntity({

--- a/src/framework/data/__tests__/createIntegrationEntity.test.ts
+++ b/src/framework/data/__tests__/createIntegrationEntity.test.ts
@@ -1,0 +1,257 @@
+import {
+  createIntegrationEntity,
+  IntegrationEntityData,
+} from '../createIntegrationEntity';
+
+const networkSourceData = {
+  id: 'natural-identifier',
+  environment: 'production',
+  CIDR: '255.255.255.0',
+  name: 'My Network',
+  notInDataModel: 'Not In Data Model',
+};
+
+const networkResourceEntity = {
+  _key: 'natural-identifier',
+  _class: ['Network'],
+  _type: 'azure_vpc',
+  _rawData: [{ name: 'default', rawData: networkSourceData }],
+  name: 'My Network',
+  displayName: 'My Network',
+  environment: 'production',
+  CIDR: '255.255.255.0',
+  public: false,
+  internal: true,
+};
+
+const networkAssigns = {
+  _class: 'Network',
+  _type: 'azure_vpc',
+  public: false,
+  internal: true,
+};
+
+const entityData: IntegrationEntityData = {
+  assign: networkAssigns,
+  source: networkSourceData,
+};
+
+describe('createIntegrationEntity', () => {
+  test('combines source with assignments', () => {
+    const entity = createIntegrationEntity({
+      entityData,
+    });
+    expect(entity).toEqual(networkResourceEntity);
+  });
+
+  test('should assign active boolean if source has Active status', () => {
+    const entity = createIntegrationEntity({
+      entityData: {
+        assign: networkAssigns,
+        source: {
+          ...networkSourceData,
+          status: 'Active',
+        },
+      },
+    });
+    expect(entity).toHaveProperty('active', true);
+  });
+
+  test('should assign createdOn timestamp from creationDate', () => {
+    const entity = createIntegrationEntity({
+      entityData: {
+        assign: networkAssigns,
+        source: {
+          ...networkSourceData,
+          creationDate: new Date('2020-01-01'),
+        },
+      },
+    });
+    expect(entity).toHaveProperty(
+      'createdOn',
+      new Date('2020-01-01').getTime(),
+    );
+  });
+
+  test('ignore source properties that are not in the data model', () => {
+    const entity = createIntegrationEntity({
+      entityData,
+    });
+    expect('notWhitelisted' in entity).toBe(false);
+  });
+
+  test('handles empty tags in source data', () => {
+    const entity = createIntegrationEntity({
+      entityData: {
+        assign: networkAssigns,
+        source: {
+          ...networkSourceData,
+          tags: [],
+        },
+      },
+    });
+    expect(entity.tags).toBeUndefined();
+  });
+
+  test('assign array of tags in source data', () => {
+    const entity = createIntegrationEntity({
+      entityData: {
+        assign: networkAssigns,
+        source: {
+          ...networkSourceData,
+          tags: [{ Key: 'a', Value: 'b' }],
+        },
+      },
+    });
+    expect(entity).toMatchObject({ 'tag.a': 'b' });
+  });
+
+  test('assign tags to common properties', () => {
+    const entity = createIntegrationEntity({
+      entityData: {
+        assign: networkAssigns,
+        source: {
+          ...networkSourceData,
+          tags: [{ Key: 'classification', Value: 'critical' }],
+        },
+      },
+    });
+    expect(entity).toMatchObject({
+      classification: 'critical',
+      'tag.classification': 'critical',
+    });
+  });
+
+  test('assign tags to specified properties', () => {
+    const entity = createIntegrationEntity({
+      entityData: {
+        assign: networkAssigns,
+        source: {
+          ...networkSourceData,
+          tags: [{ Key: 'a', Value: 'b' }],
+        },
+        tagProperties: ['a'],
+      },
+    });
+    expect(entity).toMatchObject({ a: 'b', 'tag.a': 'b' });
+  });
+
+  test('does not assign displayName without name, tag.name', () => {
+    expect(() => {
+      createIntegrationEntity({
+        entityData: {
+          assign: networkAssigns,
+          source: { ...networkSourceData, name: undefined },
+        },
+      });
+    }).toThrowError(/name/);
+  });
+
+  test('assigns displayName from name when not set by tag.name', () => {
+    const entity = createIntegrationEntity({
+      entityData: {
+        assign: networkAssigns,
+        source: networkSourceData,
+      },
+    });
+    expect(entity).toMatchObject({ displayName: 'My Network' });
+  });
+
+  test('assigns displayName from tag.name', () => {
+    const entity = createIntegrationEntity({
+      entityData: {
+        assign: networkAssigns,
+        source: {
+          ...networkSourceData,
+          tags: [{ Key: 'name', Value: 'Name from tag.name' }],
+        },
+      },
+    });
+    expect(entity).toMatchObject({ displayName: 'Name from tag.name' });
+  });
+
+  test('assigns displayName from assigns over name, tag.name', () => {
+    const entity = createIntegrationEntity({
+      entityData: {
+        assign: { ...networkAssigns, displayName: 'Literal assignment' },
+        source: {
+          ...networkSourceData,
+          tags: [{ Key: 'name', Value: 'Name from tag.name' }],
+        },
+      },
+    });
+    expect(entity).toMatchObject({ displayName: 'Literal assignment' });
+  });
+
+  test('assigns additional rawData', () => {
+    const rawData = { name: 'additional', rawData: 'anything' };
+    const entity = createIntegrationEntity({
+      entityData: {
+        assign: { ...networkAssigns, _rawData: [rawData] },
+        source: networkSourceData,
+      },
+    });
+    expect(entity._rawData).toEqual([
+      { name: 'default', rawData: entityData.source },
+      rawData,
+    ]);
+  });
+
+  test('assigning default rawData is an error', () => {
+    const rawData = { name: 'default', rawData: 'anything' };
+    expect(() =>
+      createIntegrationEntity({
+        entityData: {
+          assign: { ...networkAssigns, _rawData: [rawData] },
+          source: networkSourceData,
+        },
+      }),
+    ).toThrowError(/duplicate/i);
+  });
+
+  test('assigning duplicate rawData is an error', () => {
+    const rawData = [
+      { name: 'another', rawData: 'anything' },
+      { name: 'another', rawData: 'another' },
+    ];
+    expect(() =>
+      createIntegrationEntity({
+        entityData: {
+          assign: { ...networkAssigns, _rawData: rawData },
+          source: networkSourceData,
+        },
+      }),
+    ).toThrowError(/duplicate/i);
+  });
+
+  test('assigning duplicate rawData is an error', () => {
+    const rawData = [
+      { name: 'another', rawData: 'anything' },
+      { name: 'another', rawData: 'another' },
+    ];
+    expect(() =>
+      createIntegrationEntity({
+        entityData: {
+          assign: { ...networkAssigns, _rawData: rawData },
+          source: networkSourceData,
+        },
+      }),
+    ).toThrowError(/duplicate/i);
+  });
+
+  test('empty source is no rawData', () => {
+    expect(
+      createIntegrationEntity({
+        entityData: {
+          assign: {
+            _class: 'Account',
+            _type: 'account-type',
+            _key: 'required-when-source-cannot-be-used',
+            name: 'Name is required when not provided by source',
+          },
+          source: {},
+        },
+      })._rawData,
+    ).toEqual([]);
+  });
+});

--- a/src/framework/data/createIntegrationEntity.ts
+++ b/src/framework/data/createIntegrationEntity.ts
@@ -92,9 +92,9 @@ export type IntegrationEntityData = {
  * A generated `Entity` that includes additional properties
  * specific to the entity class and some properties are guaranteed.
  */
-type GeneratedEntity = AdditionalEntityProperties &
-  Omit<Entity, '_class'> &
-  RawDataTracking & { _class: string[] };
+type GeneratedEntity = Omit<Entity, '_class'> &
+  AdditionalEntityProperties &
+  RawDataTracking & { _class: string[]; _key: string; _type: string };
 
 export type IntegrationEntityBuilderInput = {
   /**

--- a/src/framework/data/createIntegrationEntity.ts
+++ b/src/framework/data/createIntegrationEntity.ts
@@ -1,0 +1,256 @@
+import { EntityFromIntegration } from '../../persister';
+import { validateRawData } from '../../persister/rawData';
+import { RawUploadJobInput } from '../../persister/types';
+import {
+  IntegrationEntitySchema,
+  getSchema,
+  validateEntityWithSchema,
+} from '@jupiterone/data-model';
+import { assignTags, ResourceTagList, ResourceTagMap } from './tagging';
+import { getTime } from '.';
+
+/**
+ * Properties required to build a valid `EntityFromIntegration`.
+ *
+ * These properties are more strict (than their counterpart definitions on
+ * `EntityFromIntegration`) to prevent literal assignments of `undefined`
+ * values.
+ */
+type RequiredEntityProperties = { _class: string | string[]; _type: string };
+
+/**
+ * Allows assignment of any additional properties without being forced to use
+ * specific types where that isn't helpful.
+ *
+ * During development, schema validation prevents failures to provide properties
+ * required by the entity `_class`. Combined with automatic transfer of many
+ * properties from the `ProviderSourceData`, there may be no strong case to be
+ * made for referencing specific TypeScript types. In those cases, it should be
+ * possible to provide additional literal entity properties.
+ */
+type AdditionalEntityProperties = { [key: string]: any };
+
+/**
+ * Properties to be assigned to a generated entity which are declared in code
+ * literals.
+ *
+ * Many values can be transferred from the `ProviderSourceData` without any
+ * additional effort. Other properties must transferred by using code to specify
+ * the property value. These properties can be any name/value, but the list
+ * certainly includes those of `EntityFromIntegration`, and some properties
+ * *must* be provided.
+ */
+type LiteralAssignments = Partial<EntityFromIntegration> &
+  RequiredEntityProperties &
+  AdditionalEntityProperties;
+
+/**
+ * A type representing entity data from a provider.
+ */
+type ProviderSourceData = {
+  /**
+   * Some providers include a collection of `tags` that will be stored on the
+   * generated entity as `tag.propertyName`, `propertyName` when the tag is
+   * registered in `tagProperties` or is known to be a common tag property name,
+   * and the tag values will be collected in the generated entity as `tags` (a
+   * `string[]`);
+   */
+  tags?: ResourceTagList | ResourceTagMap;
+
+  [key: string]: any;
+};
+
+/**
+ * Data used to generate an `EntityFromIntegration`.
+ */
+export type IntegrationEntityData = {
+  /**
+   * Data from a provider API that will be selectively transferred to an
+   * `EntityFromIntegration`.
+   *
+   * The common properties defined by data model schemas, selected by the
+   * `assign._class`, will be found and transferred to the generated entity.
+   */
+  source: ProviderSourceData;
+
+  /**
+   * Literal property assignments. These values will override anything
+   * transferred from the `source` data.
+   */
+  assign: LiteralAssignments;
+
+  /**
+   * The names of properties that will be assigned directly to the entity from
+   * tags with matching names. See `assignTags`.
+   */
+  tagProperties?: string[];
+};
+
+/**
+ * A generated `EntityFromIntegration` that includes additional properties
+ * specific to the entity class and some properties are guaranteed.
+ */
+type GeneratedEntityFromIntegration = EntityFromIntegration &
+  AdditionalEntityProperties & { _key: string; _class: string[] };
+
+export type IntegrationEntityBuilderInput = {
+  /**
+   * Data used to generate an `EntityFromIntegration`.
+   */
+  entityData: IntegrationEntityData;
+
+  // The plan is to allow another property that contains metadata to drive the
+  // transfer process further, placing transformations that are common to the
+  // integration in one place, and allowing transformation reuse across
+  // integrations.
+};
+
+/**
+ * Generates an `EntityFromIntegration` using the provided `entityData`.
+ *
+ * WARNING: This is a work in progress. Only certain schemas are supported as
+ * the API is worked out in the Azure integration.
+ */
+export function createIntegrationEntity(
+  input: IntegrationEntityBuilderInput,
+): GeneratedEntityFromIntegration {
+  const generatedEntity = generateEntity(input.entityData);
+
+  validateRawData(generatedEntity);
+
+  if (process.env.ENABLE_GRAPH_OBJECT_SCHEMA_VALIDATION) {
+    validateEntityWithSchema(generatedEntity);
+  }
+
+  return generatedEntity;
+}
+
+function generateEntity({
+  source,
+  assign,
+  tagProperties,
+}: IntegrationEntityData): GeneratedEntityFromIntegration {
+  const _rawData: RawUploadJobInput[] = [];
+  if (Object.entries(source).length > 0) {
+    _rawData.push({ name: 'default', rawData: source });
+  }
+  if (assign._rawData) {
+    _rawData.push(...assign._rawData);
+  }
+
+  const _key = assign._key || generateEntityKey(assign._type, source);
+  const _class = Array.isArray(assign._class) ? assign._class : [assign._class];
+
+  const entity: GeneratedEntityFromIntegration = {
+    ...whitelistedProviderData(source, _class),
+    ...assign,
+    _key,
+    _class,
+    _rawData,
+  };
+
+  if (entity.createdOn === undefined) {
+    entity.createdOn =
+      (source.createdAt && getTime(source.createdAt)) ||
+      (source.creationDate && getTime(source.creationDate)) ||
+      (source.creationTime && getTime(source.creationTime)) ||
+      (source.creationTimestamp && getTime(source.creationTimestamp));
+  }
+
+  if (entity.active === undefined && source.status) {
+    entity.active = source.status === 'Online' || source.status === 'Active';
+  }
+
+  // Remove transferred `source.tags` property from the entity. `tags` is in the
+  // schema white list, but the structure isn't what we want `tags` to be.
+  // `assignTags` will take care of preparing `tags` properly.
+  delete entity.tags;
+
+  assignTags(entity, source.tags, tagProperties);
+
+  // `assignTags` may populate `displayName` from the `source.tags`. When there
+  // is an `assign.displayName`, use that instead assuming that an assigned
+  // value is meant to override an automatic function.
+  if (assign.displayName) {
+    entity.displayName = assign.displayName;
+  }
+
+  // When a `displayName` is not derived from `source.tags` nor explicitly set
+  // by `assign.displayName`, use `entity.name`. This is a last attempt to
+  // to provide a value automatically.
+  if (!entity.displayName && entity.name) {
+    entity.displayName = entity.name;
+  }
+
+  return entity;
+}
+
+function generateEntityKey(_type: string, data: any): string {
+  const id = data.providerId || data.id;
+  if (!id) {
+    throw new Error(
+      'Entity key generation requires one of data.{providerId,id}',
+    );
+  }
+  return id;
+}
+
+function whitelistedProviderData(
+  source: ProviderSourceData,
+  _class: string[],
+): ProviderSourceData {
+  const whitelistedProviderData: ProviderSourceData = {};
+  const schemaProperties = schemaWhitelistedPropertyNames(_class);
+  for (const e of Object.entries(source)) {
+    if (schemaProperties.includes(e[0])) {
+      whitelistedProviderData[e[0]] = e[1];
+    }
+  }
+  return whitelistedProviderData;
+}
+
+const schemaWhitelists = new Map<string[], string[]>();
+
+/**
+ * Answers all the property names defined by the schemas referenced in the set
+ * of classes. Values are cached to avoid rebuilding, since there could be
+ * thousands of entities constructed during a single execution.
+ */
+function schemaWhitelistedPropertyNames(_class: string[]): string[] {
+  let properties = schemaWhitelists.get(_class);
+  if (!properties) {
+    properties = [];
+    for (const c of _class) {
+      const schema = getSchema(c);
+      if (!schema) {
+        throw new Error(
+          `Class '${c}' does not yet have a schema supported by the SDK!`,
+        );
+      }
+      properties.push(...schemaPropertyNames(schema));
+    }
+    schemaWhitelists.set(_class, properties);
+  }
+  return properties;
+}
+
+function schemaPropertyNames(schema: IntegrationEntitySchema): string[] {
+  const names: string[] = [];
+  if (schema.properties) {
+    names.push(...Object.keys(schema.properties));
+  }
+  if (schema.allOf) {
+    for (const s of schema.allOf) {
+      names.push(...schemaPropertyNames(s));
+    }
+  }
+  if (schema.$ref) {
+    const refSchema = getSchema(schema.$ref.slice(1));
+    if (refSchema) {
+      names.push(...schemaPropertyNames(refSchema));
+    } else {
+      throw new Error(`Schema $ref '${schema.$ref}' cannot be resolved!`);
+    }
+  }
+  return names;
+}

--- a/src/framework/data/createIntegrationEntity.ts
+++ b/src/framework/data/createIntegrationEntity.ts
@@ -138,7 +138,7 @@ function generateEntity({
     _rawData.push(...assign._rawData);
   }
 
-  const _key = assign._key || generateEntityKey(assign._type, source);
+  const _key = assign._key || generateEntityKey(source);
   const _class = Array.isArray(assign._class) ? assign._class : [assign._class];
 
   const entity: GeneratedEntity = {
@@ -185,7 +185,7 @@ function generateEntity({
   return entity;
 }
 
-function generateEntityKey(_type: string, data: any): string {
+function generateEntityKey(data: any): string {
   const id = data.providerId || data.id;
   if (!id) {
     throw new Error(

--- a/src/framework/data/index.ts
+++ b/src/framework/data/index.ts
@@ -1,3 +1,5 @@
 export * from './converters';
 export * from './tagging';
 export * from './ip';
+
+export * from './createIntegrationEntity';

--- a/src/framework/data/validation.ts
+++ b/src/framework/data/validation.ts
@@ -1,0 +1,20 @@
+import { RawDataTracking } from '../types';
+
+/**
+ * Validates collection of raw data, throwing an error when invalid.
+ *
+ * @param trackingEntity entity with _rawData
+ * @throws Error when a duplicate name is encountered
+ */
+export function validateRawData(trackingEntity: RawDataTracking): void {
+  if (trackingEntity._rawData) {
+    const names = new Set<string>();
+    for (const data of trackingEntity._rawData) {
+      if (names.has(data.name)) {
+        throw new Error(`Duplicate raw data name '${data.name}'!`);
+      } else {
+        names.add(data.name);
+      }
+    }
+  }
+}

--- a/src/framework/jobState/FileSystemJobState/__tests__/FileSystemJobState.test.ts
+++ b/src/framework/jobState/FileSystemJobState/__tests__/FileSystemJobState.test.ts
@@ -9,6 +9,8 @@ import {
   GRAPH_OBJECT_BUFFER_THRESHOLD,
 } from '../FileSystemJobState';
 
+import { createIntegrationEntity } from '../../../data';
+
 import { generateEntity, generateRelationship } from './util/graphObjects';
 
 import { Entity, Relationship } from '../../../types';
@@ -122,6 +124,34 @@ describe('addEntities', () => {
     // adding an additional entity should trigger the flushing
     await jobState.addEntities([generateEntity()]);
     expect(flushEntitiesSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('accepts GeneratedEntity type from createIntegrationEntity utililty', async () => {
+    const { jobState } = setupLocalStepJobState();
+
+    const networkAssigns = {
+      _class: 'Network',
+      _type: 'azure_vpc',
+      public: false,
+      internal: true,
+    };
+
+    const networkSourceData = {
+      id: 'natural-identifier',
+      environment: 'production',
+      CIDR: '255.255.255.0',
+      name: 'My Network',
+      notInDataModel: 'Not In Data Model',
+    };
+
+    const entity = createIntegrationEntity({
+      entityData: {
+        assign: networkAssigns,
+        source: networkSourceData,
+      },
+    });
+
+    await jobState.addEntities([entity]);
   });
 });
 

--- a/src/framework/jobState/FileSystemJobState/__tests__/FileSystemJobState.test.ts
+++ b/src/framework/jobState/FileSystemJobState/__tests__/FileSystemJobState.test.ts
@@ -126,7 +126,7 @@ describe('addEntities', () => {
     expect(flushEntitiesSpy).toHaveBeenCalledTimes(1);
   });
 
-  test('accepts GeneratedEntity type from createIntegrationEntity utililty', async () => {
+  test('accepts GeneratedEntity type from createIntegrationEntity utility', async () => {
     const { jobState } = setupLocalStepJobState();
 
     const networkAssigns = {

--- a/src/framework/types/entity.ts
+++ b/src/framework/types/entity.ts
@@ -1,15 +1,17 @@
 import { PersistedObject } from './persistedObject';
 
-export type Entity = PersistedObject &
-  EntityOverrides &
-  EntityAdditionalProperties;
+export type Entity = EntityCoreProperties & EntityAdditionalProperties;
+
+type EntityCoreProperties = PersistedObject & EntityOverrides & RawDataTracking;
 
 interface EntityOverrides {
   // entity can have multiple classes
   _class: string | string[];
 }
 
-type EntityAdditionalProperties = Record<string, EntityPropertyValue>;
+interface EntityAdditionalProperties {
+  [key: string]: EntityPropertyValue;
+}
 
 type EntityPropertyValue =
   | Array<string | number | boolean>
@@ -19,4 +21,49 @@ type EntityPropertyValue =
   | number[]
   | boolean
   | undefined
-  | null;
+  | null
+  | EntityRawData[];
+
+export interface RawDataTracking {
+  /**
+   * Maintains references to a collection of raw data uploads accumulated during
+   * the construction of an entity.
+   *
+   * This data will not be included in any operations delivered to the persister.
+   * Each input is placed in a queue by the `RawDataUploader` for upload to
+   * temporary storage and the associated storage URI is added to
+   * `_rawDataTempUris`.
+   */
+  _rawData?: EntityRawData[];
+}
+
+/**
+ * Raw data to store
+ */
+export type EntityRawData = {
+  /**
+   * A name that identifies the payload when there are multiple data sources
+   * used to build an entity.
+   *
+   * This name is part of a permanent key associated with the data. It must be
+   * unique within the context of the entity. `'default'` is an acceptable value
+   * when there is only one data payload, though it is recommended to use names
+   * that are more meaningful when there is more than one.
+   *
+   * For example, consider an AWS IAM Role entity, where the role has an
+   * embedded policy obtained through a separate API call:
+   *
+   * ```
+   * [
+   *   { name: 'role', ... },
+   *   { name: 'policy', ... }
+   * ]
+   * ```
+   */
+  name: string;
+
+  /**
+   * Any type of data representing the source content used to build an entity.
+   */
+  rawData: any;
+};

--- a/src/framework/types/entity.ts
+++ b/src/framework/types/entity.ts
@@ -1,10 +1,10 @@
 import { PersistedObject } from './persistedObject';
 
-export type Entity = EntityCoreProperties & EntityAdditionalProperties;
+export type Entity = EntityCoreProperties &
+  RawDataTracking &
+  EntityAdditionalProperties;
 
-type EntityCoreProperties = PersistedObject & EntityOverrides & RawDataTracking;
-
-interface EntityOverrides {
+interface EntityCoreProperties extends Omit<PersistedObject, '_class'> {
   // entity can have multiple classes
   _class: string | string[];
 }

--- a/src/framework/types/index.ts
+++ b/src/framework/types/index.ts
@@ -1,2 +1,2 @@
-export { Entity } from './entity';
-export { Relationship } from './relationship';
+export * from './entity';
+export * from './relationship';

--- a/yarn.lock
+++ b/yarn.lock
@@ -423,6 +423,13 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@jupiterone/data-model@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.2.0.tgz#c068be27d8dd91f5d250fc7666c4f88edca5eaef"
+  integrity sha512-dhRxi5T+2bWoee52KIiw7yOEam7uMe+tCWd8yaEwAOBkKCctQIiyQXrQDkEMPDobSwn0KQHwHUN38JM0eWrjIA==
+  dependencies:
+    ajv "^6.12.0"
+
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz#ecdf48d532c58ea477acfcab80348424f8d0662f"
@@ -658,7 +665,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
+ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.0, ajv@^6.5.5:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
   integrity sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==


### PR DESCRIPTION
This copies over the `createIntegrationEntity` utilities and tweaks some of the types a bit to allow the  `Entity` type defined in this repo to play nicely.