### PR TITLE
Add option for pretty logging for later use with local collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "bunyan": "^1.8.12",
+    "bunyan-format": "^0.2.1",
     "dependency-graph": "^0.9.0",
     "lodash": "^4.17.15",
     "p-map": "^4.0.0",

--- a/src/framework/execution/__tests__/dependencyGraph.test.ts
+++ b/src/framework/execution/__tests__/dependencyGraph.test.ts
@@ -25,8 +25,11 @@ import {
 } from '../types';
 
 const executionContext: IntegrationExecutionContext = {
-  logger: createIntegrationLogger('step logger', {
-    integrationSteps: [],
+  logger: createIntegrationLogger({
+    name: 'step logger',
+    invocationConfig: {
+      integrationSteps: [],
+    },
   }),
   instance: LOCAL_INTEGRATION_INSTANCE,
 };

--- a/src/framework/execution/executeIntegration.ts
+++ b/src/framework/execution/executeIntegration.ts
@@ -25,8 +25,14 @@ interface ExecuteIntegrationResult {
  * Starts local execution of an integration
  */
 export function executeIntegrationLocally(config: IntegrationInvocationConfig) {
+  const logger = createIntegrationLogger({
+    name: 'Local',
+    invocationConfig: config,
+    pretty: true,
+  });
+
   const instance = createIntegrationInstanceForLocalExecution(config);
-  const logger = createIntegrationLogger(instance.name, config);
+
   const context: IntegrationExecutionContext = {
     instance,
     logger,

--- a/src/framework/execution/index.ts
+++ b/src/framework/execution/index.ts
@@ -1,0 +1,2 @@
+export * from './executeIntegration';
+export * from './types';

--- a/src/framework/execution/logger.ts
+++ b/src/framework/execution/logger.ts
@@ -7,22 +7,39 @@ import {
   IntegrationInstanceConfigFieldMap,
 } from './types';
 
+// eslint-disable-next-line
+const bunyanFormat = require('bunyan-format');
+
+interface CreateIntegrationLoggerInput {
+  name: string;
+  invocationConfig: IntegrationInvocationConfig;
+  pretty?: boolean;
+  serializers?: Logger.Serializers;
+}
+
 /**
  * Create a logger for the integration that will include invocation details and
  * serializers common to all integrations.
  */
-export function createIntegrationLogger(
-  integrationName: string,
-  invocationConfig: IntegrationInvocationConfig,
-  serializers?: Logger.Serializers,
-): IntegrationLogger {
-  const logger = Logger.createLogger({
-    name: integrationName,
+export function createIntegrationLogger({
+  name,
+  invocationConfig,
+  pretty,
+  serializers,
+}: CreateIntegrationLoggerInput): IntegrationLogger {
+  const loggerConfig: Logger.LoggerOptions = {
+    name,
     level: (process.env.LOG_LEVEL || 'info') as Logger.LogLevel,
     serializers: {
       err: Logger.stdSerializers.err,
     },
-  });
+  };
+
+  if (pretty) {
+    loggerConfig.streams = [{ stream: bunyanFormat({ outputMode: 'short' }) }];
+  }
+
+  const logger = Logger.createLogger(loggerConfig);
 
   const serializeInstanceConfig = createInstanceConfigSerializer(
     invocationConfig.instanceConfigFields,

--- a/yarn.lock
+++ b/yarn.lock
@@ -720,6 +720,16 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
     "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
 
+ansicolors@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.2.1.tgz#be089599097b74a5c9c4a84a0cdbcdb62bd87aef"
+  integrity sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8=
+
+ansistyles@~0.1.1:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/ansistyles/-/ansistyles-0.1.3.tgz#5de60415bda071bb37127854c864f41b23254539"
+  integrity sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=
+
 any-observable@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.3.0.tgz#af933475e5806a67d0d7df090dd5e8bef65d119b"
@@ -941,6 +951,15 @@ buffer-from@1.x, buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+bunyan-format@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/bunyan-format/-/bunyan-format-0.2.1.tgz#a4b3b0d80070a865279417269e3f00ff02fbcb47"
+  integrity sha1-pLOw2ABwqGUnlBcmnj8A/wL7y0c=
+  dependencies:
+    ansicolors "~0.2.1"
+    ansistyles "~0.1.1"
+    xtend "~2.1.1"
 
 bunyan@^1.8.12:
   version "1.8.12"
@@ -3293,6 +3312,11 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
+object-keys@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-0.4.0.tgz#28a6aae7428dd2c3a92f3d95f21335dd204e0336"
+  integrity sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=
+
 object-visit@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
@@ -4581,6 +4605,13 @@ xmlchars@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xtend@~2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-2.1.2.tgz#6efecc2a4dad8e6962c4901b337ce7ba87b5d28b"
+  integrity sha1-bv7MKk2tjmlixJAbM3znuoe10os=
+  dependencies:
+    object-keys "~0.4.0"
 
 y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Some small tweaks to the integration logger to allow for pretty logging when running the integration locally. I tried mucking around a little to see if the formatter script that ships with bunyan could be used (normally done by piping output into `yarn bunyan` or `npx bunyan`), but tbh that ended up feeling pretty hacky.  

Here's what output would look like with the cli that's coming:
![prettylogs](https://user-images.githubusercontent.com/9613701/79031758-2fb1f700-7b6f-11ea-9d3a-9988c04928b1.png)
