### PR TITLE
Improve prepublish transpilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "type-check": "tsc --noEmit",
     "test": "jest",
     "test:ci": "yarn lint && yarn type-check && yarn test",
-    "prepublishOnly": "tsc --declaration"
+    "build": "tsc -p tsconfig.dist.json --declaration",
+    "prepublishOnly": "yarn build"
   },
   "dependencies": {
     "bunyan": "^1.8.12",

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -1,4 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["dist", "**/*.test.ts"]
+  "include": ["src"],
+  "exclude": ["dist", "**/*.test.ts", "**/*/__tests__/*.ts"]
 }


### PR DESCRIPTION
Building now actually references the tsconfig.dist.json file.

The dist directory now follows the same structure as src.