### PR TITLE
Add project convention file loading for later use with cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "repository": "git@github.com:JupiterOne/integration-sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
   "license": "MPL-2.0",
+  "bin": {
+    "j1-integration": "./bin/j1-integration"
+  },
   "files": [
     "dist",
     "bin"
@@ -25,10 +28,13 @@
     "async-sema": "^3.1.0",
     "bunyan": "^1.8.12",
     "bunyan-format": "^0.2.1",
+    "chalk": "^4.0.0",
+    "commander": "^5.0.0",
     "dependency-graph": "^0.9.0",
     "lodash": "^4.17.15",
     "p-map": "^4.0.0",
     "p-queue": "^6.3.0",
+    "ts-node": "^8.8.2",
     "uuid": "^7.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
   "repository": "git@github.com:JupiterOne/integration-sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
   "license": "MPL-2.0",
-  "bin": {
-    "j1-integration": "./bin/j1-integration"
-  },
   "files": [
     "dist",
     "bin"

--- a/src/cli/__mocks__/log.ts
+++ b/src/cli/__mocks__/log.ts
@@ -1,0 +1,4 @@
+import noop from 'lodash/noop';
+
+export const debug = noop;
+export const info = noop;

--- a/src/cli/__tests__/__fixtures__/typeScriptProject/src/getStepStartStates.ts
+++ b/src/cli/__tests__/__fixtures__/typeScriptProject/src/getStepStartStates.ts
@@ -1,0 +1,10 @@
+export default function getStepStartStates() {
+  return {
+    'fetch-accounts': {
+      disabled: false,
+    },
+    'fetch-users': {
+      disabled: false,
+    },
+  };
+}

--- a/src/cli/__tests__/__fixtures__/typeScriptProject/src/instanceConfigFields.json
+++ b/src/cli/__tests__/__fixtures__/typeScriptProject/src/instanceConfigFields.json
@@ -1,0 +1,6 @@
+{
+  "myConfig": {
+    "mask": true,
+    "type": "boolean"
+  }
+}

--- a/src/cli/__tests__/__fixtures__/typeScriptProject/src/steps/fetchAccounts.ts
+++ b/src/cli/__tests__/__fixtures__/typeScriptProject/src/steps/fetchAccounts.ts
@@ -1,0 +1,8 @@
+import noop from 'lodash/noop';
+
+export default {
+  id: 'fetch-accounts',
+  name: 'Fetch Accounts',
+  types: ['my_account'],
+  executionHandler: noop,
+};

--- a/src/cli/__tests__/__fixtures__/typeScriptProject/src/steps/fetchUsers.ts
+++ b/src/cli/__tests__/__fixtures__/typeScriptProject/src/steps/fetchUsers.ts
@@ -1,0 +1,8 @@
+import noop from 'lodash/noop';
+
+export default {
+  id: 'fetch-users',
+  name: 'Fetch Users',
+  types: ['my_user'],
+  executionHandler: noop,
+};

--- a/src/cli/__tests__/__fixtures__/typeScriptProject/src/validateInvocation.ts
+++ b/src/cli/__tests__/__fixtures__/typeScriptProject/src/validateInvocation.ts
@@ -1,0 +1,3 @@
+export default function validateInvocation() {
+  throw new Error('Invalid config');
+}

--- a/src/cli/__tests__/config.test.ts
+++ b/src/cli/__tests__/config.test.ts
@@ -1,0 +1,135 @@
+import path from 'path';
+import {
+  loadModuleContent,
+  loadInstanceConfigFields,
+  loadIntegrationSteps,
+  loadValidateInvocationFunction,
+  loadGetStepStartStatesFunction,
+  loadConfig,
+} from '../config';
+
+jest.mock('../log');
+
+afterEach(() => {
+  // clear require cache
+  Object.keys(require.cache).forEach((modulePath) => {
+    delete require.cache[modulePath];
+  });
+});
+
+describe('loadModuleContent', () => {
+  test('loads any module and retrieves the default export', () => {
+    loadProjectStructure('typeScriptProject');
+    expect(loadModuleContent('./src/validateInvocation')).toEqual(
+      expect.any(Function),
+    );
+  });
+});
+
+describe('TypeScript project', () => {
+  beforeEach(() => {
+    loadProjectStructure('typeScriptProject');
+  });
+
+  describe('loadInstanceConfigFields', () => {
+    test('loads "src/instanceConfigFields.json" relative to current working directory', () => {
+      const instanceConfigFields = loadInstanceConfigFields();
+      expect(instanceConfigFields).toEqual({
+        myConfig: {
+          mask: true,
+          type: 'boolean',
+        },
+      });
+    });
+
+    test('returns undefined if module is not found', () => {
+      jest
+        .spyOn(process, 'cwd')
+        .mockReturnValue('/directory/that/does/not/exist/lolololol');
+
+      const instanceConfigFields = loadInstanceConfigFields();
+      expect(instanceConfigFields).toBeUndefined();
+    });
+  });
+
+  describe('loadIntegrationSteps', () => {
+    test('loads all files stored in "src/steps" ', async () => {
+      const steps = await loadIntegrationSteps();
+      expect(steps).toEqual([
+        {
+          id: 'fetch-accounts',
+          name: 'Fetch Accounts',
+          types: ['my_account'],
+          executionHandler: expect.any(Function),
+        },
+        {
+          id: 'fetch-users',
+          name: 'Fetch Users',
+          types: ['my_user'],
+          executionHandler: expect.any(Function),
+        },
+      ]);
+    });
+  });
+
+  describe('loadValidateInvocationFunction', () => {
+    test('loads function from "src/validateInvocation" ', async () => {
+      const validateFunction = loadValidateInvocationFunction();
+      expect(validateFunction).toEqual(expect.any(Function));
+      expect(() => validateFunction()).toThrow('Invalid config');
+    });
+  });
+
+  describe('loadGetStepStartStatesFunction', () => {
+    test('loads function from "src/getStepStartStates" ', async () => {
+      const getStepStartStates = loadGetStepStartStatesFunction();
+      expect(getStepStartStates).toEqual(expect.any(Function));
+
+      expect(getStepStartStates()).toEqual({
+        'fetch-accounts': {
+          disabled: false,
+        },
+        'fetch-users': {
+          disabled: false,
+        },
+      });
+    });
+  });
+
+  describe('loadConfig', () => {
+    test('loads steps, getStepStartStates, validateFunction, and instanceConfigFields', async () => {
+      const config = await loadConfig();
+
+      expect(config).toEqual({
+        instanceConfigFields: {
+          myConfig: {
+            mask: true,
+            type: 'boolean',
+          },
+        },
+        getStepStartStates: expect.any(Function),
+        validateInvocation: expect.any(Function),
+        integrationSteps: [
+          {
+            id: 'fetch-accounts',
+            name: 'Fetch Accounts',
+            types: ['my_account'],
+            executionHandler: expect.any(Function),
+          },
+          {
+            id: 'fetch-users',
+            name: 'Fetch Users',
+            types: ['my_user'],
+            executionHandler: expect.any(Function),
+          },
+        ],
+      });
+    });
+  });
+});
+
+function loadProjectStructure(fixtureName: string) {
+  jest
+    .spyOn(process, 'cwd')
+    .mockReturnValue(path.resolve(__dirname, '__fixtures__', fixtureName));
+}

--- a/src/cli/__tests__/config.test.ts
+++ b/src/cli/__tests__/config.test.ts
@@ -76,7 +76,7 @@ describe('TypeScript project', () => {
     test('loads function from "src/validateInvocation" ', async () => {
       const validateFunction = loadValidateInvocationFunction();
       expect(validateFunction).toEqual(expect.any(Function));
-      expect(() => validateFunction()).toThrow('Invalid config');
+      expect(() => (validateFunction as any)()).toThrow('Invalid config');
     });
   });
 
@@ -85,7 +85,7 @@ describe('TypeScript project', () => {
       const getStepStartStates = loadGetStepStartStatesFunction();
       expect(getStepStartStates).toEqual(expect.any(Function));
 
-      expect(getStepStartStates()).toEqual({
+      expect((getStepStartStates as any)()).toEqual({
         'fetch-accounts': {
           disabled: false,
         },

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -1,0 +1,98 @@
+/**
+ * Load ts-node register for picking up typescript files
+ */
+require('ts-node/register/transpile-only');
+
+import path from 'path';
+import { promises as fs } from 'fs';
+
+import * as log from './log';
+
+import {
+  // IntegrationInvocationConfig,
+  IntegrationInstanceConfigFieldMap,
+  InvocationValidationFunction,
+  GetStepStartStatesFunction,
+  // IntegrationStep,
+} from '../framework/execution';
+
+/**
+ * Supports a convention over configuration approach
+ * to building integrations.
+ *
+ * ./src/instanceConfigFields
+ * ./src/steps/*
+ * ./src/getStepStartStates
+ * ./src/validateInvocation
+ */
+export async function loadConfig(): Promise<any> {
+  log.debug('Loading integration configuration...\n');
+
+  const config = {
+    instanceConfigFields: loadInstanceConfigFields(),
+    validateInvocation: loadValidateInvocationFunction(),
+    getStepStartStates: loadGetStepStartStatesFunction(),
+    integrationSteps: await loadIntegrationSteps(),
+  };
+
+  return config;
+}
+
+/**
+ * Loads instanceConfigFields from ./src/instanceConfigFields
+ */
+export function loadInstanceConfigFields() {
+  log.debug('Loading instanceConfigFields...');
+  return loadModuleContent<IntegrationInstanceConfigFieldMap>(
+    path.join('src', 'instanceConfigFields'),
+  );
+}
+
+/**
+ * Loads getStepStartStates function from ./src/getStepStartStates.(t|j)s
+ */
+export function loadValidateInvocationFunction() {
+  log.debug('Loading validateInvocation function...');
+  return loadModuleContent<InvocationValidationFunction>(
+    path.join('src', 'validateInvocation'),
+  );
+}
+
+/**
+ * Loads getStepStartStates function from ./src/getStepStartStates.(t|j)s
+ */
+export function loadGetStepStartStatesFunction() {
+  log.debug('Loading getStepStartStates function...');
+  return loadModuleContent<GetStepStartStatesFunction>(
+    path.join('src', 'getStepStartStates'),
+  );
+}
+
+export async function loadIntegrationSteps() {
+  let files: string[] = [];
+
+  const stepsDir = path.join(process.cwd(), 'src', 'steps');
+
+  try {
+    files = await fs.readdir(stepsDir);
+  } catch (err) {
+    console.error(err);
+    // failed to read directory
+  }
+
+  return files.map((file) => {
+    return loadModuleContent(path.join(stepsDir, file));
+  });
+}
+
+export function loadModuleContent<T>(relativePath: string): T | undefined {
+  let integrationModule: any;
+
+  try {
+    integrationModule = require(path.resolve(process.cwd(), relativePath));
+  } catch (err) {
+    // module not found
+  }
+
+  return integrationModule?.default ?? integrationModule;
+}

--- a/src/cli/log.ts
+++ b/src/cli/log.ts
@@ -1,0 +1,9 @@
+import chalk from 'chalk';
+
+export function debug(msg: string) {
+  console.log(`${chalk.gray(msg)}`);
+}
+
+export function info(msg: string) {
+  console.log(`${chalk.cyan(msg)}`);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -758,6 +758,11 @@ anymatch@^3.0.3:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
+
 argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
@@ -1048,6 +1053,14 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.0.0.tgz#6e98081ed2d17faab615eb52ac66ec1fe6209e72"
+  integrity sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -1167,6 +1180,11 @@ commander@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
+commander@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-5.0.0.tgz#dbf1909b49e5044f8fdaf0adc809f0c0722bdfd0"
+  integrity sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==
 
 compare-versions@^3.5.1:
   version "3.6.0"
@@ -1354,6 +1372,11 @@ diff-sequences@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
   integrity sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -3058,7 +3081,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -4355,6 +4378,17 @@ ts-jest@^25.3.0:
     semver "6.x"
     yargs-parser "^18.1.1"
 
+ts-node@^8.8.2:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.8.2.tgz#0b39e690bee39ea5111513a9d2bcdc0bc121755f"
+  integrity sha512-duVj6BpSpUpD/oM4MfhO98ozgkp3Gt9qIp3jGxwU2DFvl/3IRaEAvbLa8G60uS7C77457e/m5TMowjedeRxI1Q==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "3.1.1"
+
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
@@ -4661,3 +4695,8 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
This PR adds loading in an integration's invocation config based on an project structure convention.

Expected structure relative to where the cli is run.
```
src/instanceConfigFields.json
src/validateInvocation.ts
src/getStepStartStates.ts
src/steps/*
```
ATM this works for both typescript and javascript projects, but I only wrote tests for typescript projects now since that's our target audience this week. I'll add tests to ensure plain js projects work down the road (would be quick).

Let me know if you want changes to where files should live.