### PR TITLE
Add CHANGELOG.md to template to encourage documenting changes

### DIFF
--- a/template/.prettierrc
+++ b/template/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "all",
+  "proseWrap": "always",
+  "singleQuote": true
+}

--- a/template/CHANGELOG.md
+++ b/template/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/template/prettier.config.js
+++ b/template/prettier.config.js
@@ -1,5 +1,0 @@
-module.exports = {
-  trailingComma: 'all',
-  proseWrap: 'always',
-  singleQuote: true,
-};


### PR DESCRIPTION
Switch prettier config to .prettierrc to match other config files (small bonus change while I'm in this dir)

I think we should (going forward) keep a changelog for integrations. It will help consumers of our integrations understand the changes being made to their graph.