### PR TITLE
Suppress eslint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,9 @@
         {
           "functions": false
         }
-      ]
+      ],
+      "@typescript-eslint/explicit-function-return-type": "off",
+      "@typescript-eslint/no-explicit-any": "off"
     }
   },
   "prettier": {

--- a/src/framework/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
+++ b/src/framework/storage/FileSystemGraphObjectStore/__tests__/FileSystemGraphObjectStore.test.ts
@@ -150,6 +150,7 @@ describe('addEntities', () => {
   });
 
   test('accepts GeneratedEntity type from createIntegrationEntity utility', async () => {
+    expect.assertions(0);
     const { store } = setupFileSystemObjectStore();
 
     const networkAssigns = {
@@ -199,6 +200,7 @@ describe('addRelationships', () => {
   });
 
   test('accepts Relationship from createIntegrationRelationship utility', async () => {
+    expect.assertions(0);
     const { store } = setupFileSystemObjectStore();
 
     const networkAssigns = {


### PR DESCRIPTION
We have these rules off in our [internal eslint config](https://bitbucket.org/lifeomic/typescript-tools/src/27c6707b50776a6d361cc9d41c1e6fd1a35e5831/config/eslint-base.json#lines-16).

The tests that have the `expect.assertions(0)` do not have assertions because they are typescript "fit" tests.