### PR TITLE
Add build workflow for template projects

### DIFF
--- a/template/.github/workflows/build.yml
+++ b/template/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: Build
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [10.x, 12.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - id: setup-node
+        name: Setup Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Check out code repository source code
+        uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Run build
+        run: yarn build


### PR DESCRIPTION
Github only looks at the `.github/workflows` dir from the root for determining if there's an action to perform, so keeping this in the template is safe.