### PR TITLE
Create context test util

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 dist
 template
+testing.d.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Exposed `createMockExecutionContext` function from
+  `@jupiterone/integration-sdk/testing` to assist with unit testing the
+  `validateInvocation` and `getStepStartState` functions.
+
 ## 0.2.2 - 2020-04-15
 
 ### Changed

--- a/docs/development.md
+++ b/docs/development.md
@@ -615,6 +615,11 @@ original provider data under a `_rawData` field. For now, this will always
 assume that data coming in was stored as `json`, but support for other data
 types will come later.
 
+#### Testing
+
+Please see [testing.md](./testing.md) for more information about testing
+utilities exposed by this project.
+
 ### Auto-magic behind the framework
 
 #### Event reporting

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,75 @@
+# Integration testing
+
+To make testing integrations easy, we expose some utilties from
+`@jupiterone/integration-sdk/testing` to help with performing common actions.
+
+## Utilities
+
+### Unit testing
+
+#### `createMockExecutionContext`
+
+For simple unit testing of the `getStepStartStates` and the `validateInvocation`
+functions, we expose a utility for creating a mock execution context.
+
+This function accepts options to populate the integration instance's `config`
+field to help with testing different code paths.
+
+Usage:
+
+```typescript
+// creates a simple execution context with a mocked
+// logger and instance without a configuration
+const simpleContext = createMockExecutionContext();
+/**
+ * Returns:
+ *
+ * {
+ *   logger: <mockLogger>,
+ *   instance: <local integration instance>
+ * }
+ */
+
+// creates an execution context with a mocked
+// logger and instance populated with the input config
+const contextWithInstanceConfig = createMockExecutionContext({
+  instanceConfig: {
+    apiKey: 'test',
+  },
+});
+/**
+ * Returns:
+ *
+ * {
+ *   logger: <mock integration logger>,
+ *   instance: {...<local integration instance>, config: { apiKey: 'test' } }
+ * }
+ */
+```
+
+Example usage in a test:
+
+```typescript
+import { createMockExecutionContext } from '@jupiterone/integration-sdk/testing';
+import getStepStartStates from './getStepStartStates';
+
+test('disables "fetch-accounts" step if "skipAccounts" is set to true on the instance config', () => {
+  const context = createMockExecutionContext({
+    instanceConfig: {
+      apiKey: 'test',
+      skipAccounts: true,
+    },
+  });
+
+  const stepStartStates = getStepStartStates(context);
+
+  expect(getStepStartStates).toEqual({
+    'fetch-accounts': {
+      disabled: true,
+    },
+    'other-step': {
+      disabled: false,
+    },
+  });
+});
+```

--- a/src/testing/__tests__/context.test.ts
+++ b/src/testing/__tests__/context.test.ts
@@ -1,0 +1,22 @@
+import noop from 'lodash/noop';
+
+import { LOCAL_INTEGRATION_INSTANCE } from '../../framework/execution/instance';
+
+import { createMockExecutionContext } from '../context';
+
+test('generates an execution context with a fake logger', () => {
+  const { logger } = createMockExecutionContext();
+
+  Object.keys(logger).forEach((key) => {
+    if (key !== 'child') {
+      expect(logger[key]).toEqual(noop);
+    }
+  });
+
+  expect(logger.child({})).toEqual(logger);
+});
+
+test('generates an execution context with the integration instance used for local development', () => {
+  const { instance } = createMockExecutionContext();
+  expect(instance).toEqual(LOCAL_INTEGRATION_INSTANCE);
+});

--- a/src/testing/context.ts
+++ b/src/testing/context.ts
@@ -1,0 +1,23 @@
+import { IntegrationInstance, IntegrationExecutionContext } from '../framework';
+
+import { LOCAL_INTEGRATION_INSTANCE } from '../framework/execution/instance';
+
+import { createMockIntegrationLogger } from './logger';
+
+interface CreateMockExecutionContextOptions {
+  instanceConfig?: IntegrationInstance['config'];
+}
+
+export function createMockExecutionContext({
+  instanceConfig,
+}: CreateMockExecutionContextOptions = {}): IntegrationExecutionContext {
+  const logger = createMockIntegrationLogger();
+  // copy local instance properties so that tests cannot
+  // mutate the original object and cause unpredicable behavior
+  const instance = { ...LOCAL_INTEGRATION_INSTANCE, config: instanceConfig };
+
+  return {
+    logger,
+    instance,
+  };
+}

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,0 +1,2 @@
+export * from './context';
+export * from './logger';

--- a/src/testing/logger.ts
+++ b/src/testing/logger.ts
@@ -1,0 +1,18 @@
+import { IntegrationLogger } from '../framework';
+import noop from 'lodash/noop';
+
+export function createMockIntegrationLogger(): IntegrationLogger {
+  const logger: IntegrationLogger = {
+    trace: noop,
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+    fatal: noop,
+    child() {
+      return this;
+    },
+  };
+
+  return logger;
+}

--- a/testing.d.ts
+++ b/testing.d.ts
@@ -1,0 +1,1 @@
+export * from './dist/testing';

--- a/testing.js
+++ b/testing.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/testing');

--- a/tsconfig.dist.json
+++ b/tsconfig.dist.json
@@ -3,6 +3,7 @@
   "include": ["src"],
   "exclude": [
     "dist",
+    "template",
     "**/*.test.ts",
     "**/*/__tests__/**/*.ts",
     "**/*/__mocks__/**/*.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "pretty": true,
     "esModuleInterop": true
   },
-  "exclude": ["dist", "template"]
+  "exclude": ["testing.d.ts", "dist", "template"]
 }


### PR DESCRIPTION
This PR exposes a method of exposing testing utilities from `@jupiterone/integration-sdk/testing`. The first utility exposed is a `createMockExecutionContext` function to help construct a context object for unit testing the `validateInvocation` and `getStartStepStates` functions.

Exposing testing utils from the `@jupiterone/integration-sdk/testing` helps avoid stuffing in non-essential components of integration execution in the core runtime and keeps the main interface lean.