### PR TITLE
Specify node engines in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added `engines` entry in package.json to denote package is intended to be used
+  with active Node.js LTS versions (`v10.x` and `v12.x`).
+
 ## 0.3.1 - 2020-04-17
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "repository": "git@github.com:JupiterOne/integration-sdk.git",
   "author": "JupiterOne <dev@jupiterone.io>",
   "license": "MPL-2.0",
+  "engines": {
+    "node": "10.x || 12.x"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Tiny change to make it clear what versions of node we expect consumers to use this with. It's explicit about `10.x` and `12.x` because that's what we run tests against.