### PR TITLE
Add createMockStepExecutionContext function to testing lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 - Added `engines` entry in package.json to denote package is intended to be used
   with active Node.js LTS versions (`v10.x` and `v12.x`).
+- Exposed `createMockStepExecutionContext` function from
+  `@jupiterone/integration-sdk/testing` to assist with unit testing steps.
 
 ## 0.3.1 - 2020-04-17
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -106,10 +106,10 @@ test('should generate the expected entities and relationships', () => {
 ```
 
 This function accepts the same options as `createMockExecutionContext` but also
-allows for `entities` and `relationships` to also be input passed in. This is
-helpful for setting up tests for steps that rely on data from another step. The
-`entities` and `relationships` passed in via the options are _not_ included in
-the `collectedEntities` and `collectedRelationships` arrays.
+allows passing `entities` and `relationships`. This is helpful for setting up
+tests for steps that rely on data from another step. The `entities` and
+`relationships` passed in via the options are _not_ included in the
+`collectedEntities` and `collectedRelationships` arrays.
 
 Input data is omitted from the `collected*` properties because step tests should
 only have to focus on asserting the generation of new data from based on the
@@ -123,10 +123,10 @@ import { createMockStepExecutionContext } from '@jupiterone/integration-sdk/test
 
 test('should generate the expected entities and relationships', () => {
   const previousStepEntities = [entityA];
-  const previousStepRelationships = [entityB, entityC];
+  const previousStepRelationships = [relationshipA, relationshipB];
 
   const expectedGeneratedEntities = [expectedEntityA];
-  const expectedGeneratedRelationships = [relationshipA];
+  const expectedGeneratedRelationships = [expectedRelationshipA];
 
   const context = createMockStepExecutionContext({
     entities: previousStepEntities,
@@ -135,9 +135,9 @@ test('should generate the expected entities and relationships', () => {
 
   await step.executionHandler(context);
 
-  expect(context.jobState.collectedEntities).toEqual(expectedEntities);
+  expect(context.jobState.collectedEntities).toEqual(expectedGeneratedEntities);
   expect(context.jobState.collectedRelationships).toEqual(
-    expectedRelationships,
+    expectedGeneratedRelationships,
   );
 });
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -112,8 +112,8 @@ helpful for setting up tests for steps that rely on data from another step. The
 the `collectedEntities` and `collectedRelationships` arrays.
 
 Input data is omitted from the `collected*` properties because step tests should
-only have to focus on asserting the generation of new data from based on the old
-state.
+only have to focus on asserting the generation of new data from based on the
+previous set of data.
 
 For example:
 

--- a/src/testing/__tests__/context.test.ts
+++ b/src/testing/__tests__/context.test.ts
@@ -9,7 +9,11 @@ import {
 } from '../context';
 
 /**
- * Ensure that createMockExecutionContext provides the same options as
+ * Ensure that both createMockExecutionContext and
+ * createMockStepExecutionContext functions return
+ * an integration logger and instance.
+ *
+ * Also ensure that they can accept the `instanceConfig` option.
  */
 [createMockExecutionContext, createMockStepExecutionContext].forEach(
   (createContext) => {

--- a/src/testing/__tests__/context.test.ts
+++ b/src/testing/__tests__/context.test.ts
@@ -1,22 +1,87 @@
 import noop from 'lodash/noop';
 
+import { Entity, Relationship, IntegrationStep } from '../../framework';
 import { LOCAL_INTEGRATION_INSTANCE } from '../../framework/execution/instance';
 
-import { createMockExecutionContext } from '../context';
+import {
+  createMockExecutionContext,
+  createMockStepExecutionContext,
+} from '../context';
 
-test('generates an execution context with a fake logger', () => {
-  const { logger } = createMockExecutionContext();
+/**
+ * Ensure that createMockExecutionContext provides the same options as
+ */
+[createMockExecutionContext, createMockStepExecutionContext].forEach(
+  (createContext) => {
+    describe(createContext.name, () => {
+      test('generates an execution context with a fake logger', () => {
+        const { logger } = createContext();
 
-  Object.keys(logger).forEach((key) => {
-    if (key !== 'child') {
-      expect(logger[key]).toEqual(noop);
-    }
+        Object.keys(logger).forEach((key) => {
+          if (key !== 'child') {
+            expect(logger[key]).toEqual(noop);
+          }
+        });
+
+        expect(logger.child({})).toEqual(logger);
+      });
+
+      test('generates an execution context with the integration instance used for local development', () => {
+        const { instance } = createContext();
+        expect(instance).toEqual(LOCAL_INTEGRATION_INSTANCE);
+      });
+
+      test('accepts an instanceConfig for prepopulating configuration values', () => {
+        const config = { test: true };
+        const { instance } = createContext({ instanceConfig: config });
+        expect(instance).toEqual({ ...LOCAL_INTEGRATION_INSTANCE, config });
+      });
+    });
+  },
+);
+
+describe('createMockStepExecutionContext', () => {
+  test('accepts entities and relationships to initialize job state with', async () => {
+    const entities: Entity[] = [
+      {
+        _key: 'test',
+        _type: 'test_entity',
+        _class: 'Resource',
+      },
+    ];
+
+    const relationships: Relationship[] = [
+      {
+        _key: 'a|has|b',
+        _type: 'test_relationship',
+        _class: 'HAS',
+        _fromEntityKey: 'a',
+        _toEntityKey: 'b',
+      },
+    ];
+
+    const { jobState } = createMockStepExecutionContext();
+
+    jobState.addEntities(entities);
+    jobState.addRelationships(relationships);
+
+    expect(jobState.collectedEntities).toEqual(entities);
+    expect(jobState.collectedRelationships).toEqual(relationships);
   });
 
-  expect(logger.child({})).toEqual(logger);
-});
+  test('fits into the integration step interface', async () => {
+    expect.assertions(0);
 
-test('generates an execution context with the integration instance used for local development', () => {
-  const { instance } = createMockExecutionContext();
-  expect(instance).toEqual(LOCAL_INTEGRATION_INSTANCE);
+    const step: IntegrationStep = {
+      id: 'step-a',
+      name: 'My step',
+      types: [],
+      executionHandler() {
+        return Promise.resolve();
+      },
+    };
+
+    const context = createMockStepExecutionContext();
+    await step.executionHandler(context);
+  });
 });

--- a/src/testing/__tests__/jobState.test.ts
+++ b/src/testing/__tests__/jobState.test.ts
@@ -1,0 +1,120 @@
+import { Entity, Relationship } from '../../framework';
+
+import { MockJobState, createMockJobState } from '../jobState';
+
+describe('entities', () => {
+  const inputEntities: Entity[] = [
+    {
+      _type: 'test_a',
+      _class: 'Resource',
+      _key: 'a',
+    },
+    {
+      _type: 'test_a',
+      _class: 'Resource',
+      _key: 'b',
+    },
+    {
+      _type: 'test_b',
+      _class: 'Resource',
+      _key: 'c',
+    },
+  ];
+
+  test('creates a job state object that can collect and query entities', async () => {
+    expect.hasAssertions();
+    const jobState = createMockJobState();
+    await jobState.addEntities(inputEntities);
+
+    await assertEntityFilteringCapabilities(jobState);
+
+    expect(jobState.collectedEntities).toEqual(inputEntities);
+  });
+
+  test('does not include pre-existing entities in collectedEntities', async () => {
+    expect.hasAssertions();
+    const jobState = createMockJobState({ entities: inputEntities });
+    await assertEntityFilteringCapabilities(jobState);
+
+    expect(jobState.collectedEntities).toEqual([]);
+  });
+
+  async function assertEntityFilteringCapabilities(jobState: MockJobState) {
+    const entitiesA: Entity[] = [];
+    await jobState.iterateEntities({ _type: 'test_a' }, (e) => {
+      entitiesA.push(e);
+    });
+
+    const entitiesB: Entity[] = [];
+    await jobState.iterateEntities({ _type: 'test_b' }, (e) => {
+      entitiesB.push(e);
+    });
+
+    expect(entitiesA).toEqual([inputEntities[0], inputEntities[1]]);
+    expect(entitiesB).toEqual([inputEntities[2]]);
+  }
+});
+
+describe('relationships', () => {
+  const inputRelationships: Relationship[] = [
+    {
+      _type: 'test_a',
+      _class: 'HAS',
+      _key: 'a|test|b',
+      _toEntityKey: 'a',
+      _fromEntityKey: 'b',
+    },
+    {
+      _type: 'test_a',
+      _class: 'HAS',
+      _key: 'b|test|c',
+      _toEntityKey: 'b',
+      _fromEntityKey: 'c',
+    },
+    {
+      _type: 'test_b',
+      _class: 'HAS',
+      _key: 'c|test|d',
+      _toEntityKey: 'c',
+      _fromEntityKey: 'd',
+    },
+  ];
+
+  test('creates a job state object that can collect and query entities', async () => {
+    expect.hasAssertions();
+    const jobState = createMockJobState();
+    await jobState.addRelationships(inputRelationships);
+
+    await assertRelationshipFilteringCapabilities(jobState);
+
+    expect(jobState.collectedRelationships).toEqual(inputRelationships);
+  });
+
+  test('does not include pre-existing relationships in collectedRelationships', async () => {
+    expect.hasAssertions();
+    const jobState = createMockJobState({ relationships: inputRelationships });
+    await assertRelationshipFilteringCapabilities(jobState);
+
+    expect(jobState.collectedRelationships).toEqual([]);
+  });
+
+  async function assertRelationshipFilteringCapabilities(
+    jobState: MockJobState,
+  ) {
+    const relationshipsA: Relationship[] = [];
+    await jobState.iterateRelationships({ _type: 'test_a' }, (e) => {
+      relationshipsA.push(e);
+    });
+
+    const relationshipsB: Relationship[] = [];
+    await jobState.iterateRelationships({ _type: 'test_b' }, (e) => {
+      relationshipsB.push(e);
+    });
+
+    expect(relationshipsA).toEqual([
+      inputRelationships[0],
+      inputRelationships[1],
+    ]);
+    expect(relationshipsB).toEqual([inputRelationships[2]]);
+  }
+});

--- a/src/testing/__tests__/jobState.test.ts
+++ b/src/testing/__tests__/jobState.test.ts
@@ -80,7 +80,7 @@ describe('relationships', () => {
     },
   ];
 
-  test('creates a job state object that can collect and query entities', async () => {
+  test('creates a job state object that can collect and query relationships', async () => {
     expect.hasAssertions();
     const jobState = createMockJobState();
     await jobState.addRelationships(inputRelationships);

--- a/src/testing/context.ts
+++ b/src/testing/context.ts
@@ -1,8 +1,17 @@
-import { IntegrationInstance, IntegrationExecutionContext } from '../framework';
+import {
+  IntegrationInstance,
+  IntegrationExecutionContext,
+  IntegrationStepExecutionContext,
+} from '../framework';
 
 import { LOCAL_INTEGRATION_INSTANCE } from '../framework/execution/instance';
 
 import { createMockIntegrationLogger } from './logger';
+import {
+  MockJobState,
+  createMockJobState,
+  CreateMockJobStateOptions,
+} from './jobState';
 
 interface CreateMockExecutionContextOptions {
   instanceConfig?: IntegrationInstance['config'];
@@ -19,5 +28,22 @@ export function createMockExecutionContext({
   return {
     logger,
     instance,
+  };
+}
+
+type CreateMockStepExecutionContextOptions = CreateMockExecutionContextOptions &
+  CreateMockJobStateOptions;
+
+interface MockIntegrationStepExecutionContext
+  extends IntegrationStepExecutionContext {
+  jobState: MockJobState;
+}
+
+export function createMockStepExecutionContext(
+  options: CreateMockStepExecutionContextOptions = {},
+): MockIntegrationStepExecutionContext {
+  return {
+    ...createMockExecutionContext(options),
+    jobState: createMockJobState(options),
   };
 }

--- a/src/testing/jobState.ts
+++ b/src/testing/jobState.ts
@@ -1,0 +1,70 @@
+import { JobState, Entity, Relationship } from '../framework';
+
+export interface CreateMockJobStateOptions {
+  entities?: Entity[];
+  relationships?: Relationship[];
+}
+
+/**
+ * For convenience, the mock job state allows for
+ * easier access to all collected data
+ */
+export interface MockJobState extends JobState {
+  collectedEntities: Entity[];
+  collectedRelationships: Relationship[];
+}
+
+/**
+ * Creates an in memory version of a jobState object.
+ *
+ * An initial set of entities and relationships
+ * to be optionally be provided for testing dependent steps
+ * that require iterating over a previously pulled in set of
+ * entities.
+ */
+export function createMockJobState({
+  entities: inputEntities = [],
+  relationships: inputRelationships = [],
+}: CreateMockJobStateOptions = {}): MockJobState {
+  let collectedEntities: Entity[] = [];
+  let collectedRelationships: Relationship[] = [];
+
+  return {
+    get collectedEntities() {
+      return collectedEntities;
+    },
+
+    get collectedRelationships() {
+      return collectedRelationships;
+    },
+
+    addEntities: async (newEntities) => {
+      collectedEntities = collectedEntities.concat(newEntities);
+    },
+
+    addRelationships: async (newRelationships) => {
+      collectedRelationships = collectedRelationships.concat(newRelationships);
+    },
+
+    iterateEntities: async (filter, iteratee) => {
+      const filteredEntities = [...inputEntities, ...collectedEntities].filter(
+        (e) => e._type === filter._type,
+      );
+      for (const entity of filteredEntities) {
+        await iteratee(entity);
+      }
+    },
+
+    iterateRelationships: async (filter, iteratee) => {
+      const filteredRelationships = [
+        ...inputRelationships,
+        ...collectedRelationships,
+      ].filter((r) => r._type === filter._type);
+      for (const relationship of filteredRelationships) {
+        await iteratee(relationship);
+      }
+    },
+
+    flush: (): Promise<void> => Promise.resolve(),
+  };
+}


### PR DESCRIPTION
I'm hoping that this function + the easier access to collected data from the `jobState` + Polly.js should make testing steps easy.