### PR TITLE
Use .env to load instance config when using mock context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- `createMockExecutionContext` and `createMockStepExecutionContext` will now
+  attempt utilize the fields specified in `src/instanceConfigField.json` to
+  populate the instance `config` when testing.
+- Messages about loading in individual parts of the config are no longer shown
+  when running `j1-integration collect`.
+
 ## 0.4.0 - 2020-04-17
 
 ### Added

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -13,7 +13,10 @@ For simple unit testing of the `getStepStartStates` and the `validateInvocation`
 functions, we expose a utility for creating a mock execution context.
 
 This function accepts options to populate the integration instance's `config`
-field to help with testing different code paths.
+field to help with testing different code paths via the `instanceConfig` option.
+If the `instanceConfig` option is not set, the SDK will read the
+`src/instanceConfigFields.json` and load in values from environment variables
+and the project's `.env` file if present.
 
 Usage:
 

--- a/src/__tests__/loadProjectStructure.ts
+++ b/src/__tests__/loadProjectStructure.ts
@@ -5,3 +5,10 @@ export function loadProjectStructure(fixtureName: string) {
     .spyOn(process, 'cwd')
     .mockReturnValue(path.resolve(__dirname, '__fixtures__', fixtureName));
 }
+
+export function restoreProjectStructure() {
+  const maybeCwdMock = process.cwd;
+  if (jest.isMockFunction(maybeCwdMock)) {
+    maybeCwdMock.mockReset();
+  }
+}

--- a/src/framework/config.ts
+++ b/src/framework/config.ts
@@ -44,7 +44,6 @@ export async function loadConfig(): Promise<IntegrationInvocationConfig> {
  * Loads instanceConfigFields from ./src/instanceConfigFields
  */
 export function loadInstanceConfigFields() {
-  log.debug('Loading instanceConfigFields...');
   return loadModuleContent<IntegrationInstanceConfigFieldMap>(
     path.join('src', 'instanceConfigFields'),
   );
@@ -54,7 +53,6 @@ export function loadInstanceConfigFields() {
  * Loads getStepStartStates function from ./src/getStepStartStates.(t|j)s
  */
 export function loadValidateInvocationFunction() {
-  log.debug('Loading validateInvocation function...');
   return loadModuleContent<InvocationValidationFunction>(
     path.join('src', 'validateInvocation'),
   );
@@ -64,7 +62,6 @@ export function loadValidateInvocationFunction() {
  * Loads getStepStartStates function from ./src/getStepStartStates.(t|j)s
  */
 export function loadGetStepStartStatesFunction() {
-  log.debug('Loading getStepStartStates function...');
   return loadModuleContent<GetStepStartStatesFunction>(
     path.join('src', 'getStepStartStates'),
   );

--- a/src/testing/__tests__/context.test.ts
+++ b/src/testing/__tests__/context.test.ts
@@ -4,6 +4,11 @@ import { Entity, Relationship, IntegrationStep } from '../../framework';
 import { LOCAL_INTEGRATION_INSTANCE } from '../../framework/execution/instance';
 
 import {
+  loadProjectStructure,
+  restoreProjectStructure,
+} from '../../__tests__/loadProjectStructure';
+
+import {
   createMockExecutionContext,
   createMockStepExecutionContext,
 } from '../context';
@@ -18,6 +23,12 @@ import {
 [createMockExecutionContext, createMockStepExecutionContext].forEach(
   (createContext) => {
     describe(createContext.name, () => {
+      afterEach(() => {
+        delete process.env.MY_BOOLEAN_CONFIG;
+        delete process.env.MY_STRING_CONFIG;
+        restoreProjectStructure();
+      });
+
       test('generates an execution context with a fake logger', () => {
         const { logger } = createContext();
 
@@ -39,6 +50,18 @@ import {
         const config = { test: true };
         const { instance } = createContext({ instanceConfig: config });
         expect(instance).toEqual({ ...LOCAL_INTEGRATION_INSTANCE, config });
+      });
+
+      test('loads instance config values if .env is present', () => {
+        loadProjectStructure('typeScriptProject');
+
+        const { instance } = createContext();
+        expect(instance).toEqual({
+          ...LOCAL_INTEGRATION_INSTANCE,
+          config: {
+            myConfig: false,
+          },
+        });
       });
     });
   },


### PR DESCRIPTION
This should help out with setting up test scenarios when developing locally without having devs need to manually set environment variables or use `dotenv`.

I removed some logging from the individual `load*` functions exposed by `src/framework/config.ts` because I didn't want those messages to add to test output. IMO those messages are not super useful anyway. If we find it's worth bringing back those messages, I say we do it with more useful messaging (ex. "x file was detected, loading") and in a separate PR.