### PR TITLE
add polly config optios to setupRecording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
-## 0.6.1 - 2020-04-21
-
 ### Fixed
 
 - Fixed issue with dependency graph failing to wait for step dependencies to
   complete prior to performing more work
+
+### Added
+
+- `setupRecording` takes an optional parameter `options` which allows developers
+  to pass in parameters found in polly's `PollyConfig` interface.
 
 ## 0.6.0 - 2020-04-21
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -276,6 +276,10 @@ provide a `mutateEntry` function to make tweaks. This can be helpful for
 situations where sensitive data is stored in the response or request's body and
 needs to be hidden.
 
+Because `setupRecording` inherits from `setupPolly`, developers can use the
+`options` parameter to pass in any configuration parameters available in
+[`PollyConfig`](https://github.com/Netflix/pollyjs/blob/master/docs/configuration.md).
+
 Example usage in test:
 
 ```typescript
@@ -294,6 +298,9 @@ test('should generate the expected entities and relationships', () => {
     name: 'my awesome recording',
     directory: __dirname,
     redactedRequestHeaders: ['api-secret-key'],
+    options: {
+      recordFailedRequests: true,
+    },
   });
 
   const resources = [];

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -300,6 +300,11 @@ test('should generate the expected entities and relationships', () => {
     redactedRequestHeaders: ['api-secret-key'],
     options: {
       recordFailedRequests: true,
+      matchRequestsBy: {
+        url: {
+          query: false,
+        },
+      },
     },
   });
 

--- a/src/testing/__tests__/recording.test.ts
+++ b/src/testing/__tests__/recording.test.ts
@@ -16,15 +16,12 @@ jest.mock('fs');
 let recording: Recording;
 let server;
 
-beforeAll(async () => {
+beforeEach(async () => {
   server = await startServer();
 });
 
-afterAll(async () => {
+afterEach(async () => {
   await server.close();
-});
-
-afterEach(() => {
   recording.stop();
   vol.reset();
 });
@@ -78,9 +75,6 @@ test('accepts recordFailedRequests PollyConfig option', async () => {
       toUnixPath(path.resolve(__dirname, '__recordings__', name)),
     ),
   ).toEqual(true);
-
-  server.close();
-  server = await startServer();
 });
 
 test('redacts cookies from responses', async () => {

--- a/src/testing/__tests__/recording.test.ts
+++ b/src/testing/__tests__/recording.test.ts
@@ -181,6 +181,28 @@ test('allows for entries to be mutated via mutateEntry function', async () => {
   expect(har.log.entries[0].request.headers).toEqual([]);
 });
 
+test('allows for overriding matchRequestBy options with deepDefault', async () => {
+  recording = setupRecording({
+    name: 'test',
+    directory: __dirname,
+    options: {
+      matchRequestsBy: {
+        order: false,
+        url: {
+          query: false,
+        },
+      },
+    },
+  });
+
+  await fetch(`http://localhost:${server.port}/query?q=1`);
+  await fetch(`http://localhost:${server.port}/query?q=2`);
+  await recording.stop();
+
+  const har = await getRecording();
+  expect(har.log.entries).toHaveLength(1);
+});
+
 async function startServer(statusCode?: number) {
   statusCode = statusCode ? statusCode : 200;
   const server = http.createServer((req, res) => {

--- a/src/testing/recording.ts
+++ b/src/testing/recording.ts
@@ -1,6 +1,6 @@
 import { Har } from 'har-format';
 
-import { Polly } from '@pollyjs/core';
+import { Polly, PollyConfig } from '@pollyjs/core';
 import NodeHttpAdapter from '@pollyjs/adapter-node-http';
 import FSPersister from '@pollyjs/persister-fs';
 
@@ -15,6 +15,7 @@ interface SetupRecordingInput {
   redactedRequestHeaders?: string[];
   redactedResponseHeaders?: string[];
   mutateEntry?: (entry: any) => void;
+  options?: PollyConfig;
 }
 
 /**
@@ -29,6 +30,7 @@ export function setupRecording({
   redactedRequestHeaders = [],
   redactedResponseHeaders = [],
   mutateEntry,
+  options,
 }: SetupRecordingInput): Polly {
   const redactedRequestHeadersSet = new Set<string>(
     redactedRequestHeaders.map((h) => h.toLowerCase()),
@@ -75,6 +77,7 @@ export function setupRecording({
   }
 
   return new Polly(name, {
+    ...options,
     adapters: ['node-http'],
     persister: JupiterOneIntegationFSPersister,
     persisterOptions: {

--- a/src/testing/recording.ts
+++ b/src/testing/recording.ts
@@ -1,4 +1,5 @@
 import { Har } from 'har-format';
+import defaultsDeep from 'lodash/defaultsDeep';
 
 import { Polly, PollyConfig } from '@pollyjs/core';
 import NodeHttpAdapter from '@pollyjs/adapter-node-http';
@@ -76,8 +77,7 @@ export function setupRecording({
     }
   }
 
-  return new Polly(name, {
-    ...options,
+  const defaultOptions = {
     adapters: ['node-http'],
     persister: JupiterOneIntegationFSPersister,
     persisterOptions: {
@@ -89,5 +89,6 @@ export function setupRecording({
       headers: false,
       body: false,
     },
-  });
+  };
+  return new Polly(name, defaultsDeep(options, defaultOptions));
 }


### PR DESCRIPTION
Some of my integration tests include `404` responses from `user` endpoints, and users are instead recorded with abridged data (name, email, userId).

I would like to pass all of the `PollyOptions` through `setupRecording` so that developers can use options like `recordFailedRequests: true` while creating integrations.