### PR TITLE
Fix issue dependency graph execution not waiting until dependencies have completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue with dependency graph failing wait for step dependencies to
+  complete prior to performing more work
+
 ## 0.6.0 - 2020-04-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ### Fixed
 
-- Fixed issue with dependency graph failing wait for step dependencies to
+- Fixed issue with dependency graph failing to wait for step dependencies to
   complete prior to performing more work
 
 ## 0.6.0 - 2020-04-21

--- a/src/framework/execution/__tests__/dependencyGraph.test.ts
+++ b/src/framework/execution/__tests__/dependencyGraph.test.ts
@@ -163,13 +163,13 @@ describe('executeStepDependencyGraph', () => {
   test("waits for all of a steps's dependencies to complete prior to executing", async () => {
     let resolveA;
     const spyA = jest.fn(() => {
-      return new Promise((resolve) => {
+      return new Promise<void>((resolve) => {
         resolveA = resolve;
       });
     });
 
     const spyB = jest.fn(() => {
-      return new Promise((resolve) => {
+      return new Promise<void>(() => {
         // never resolve
       });
     });
@@ -199,7 +199,7 @@ describe('executeStepDependencyGraph', () => {
     ];
 
     const graph = buildStepDependencyGraph(steps);
-    const executionPromise = executeStepDependencyGraph(
+    executeStepDependencyGraph(
       executionContext,
       graph,
       getDefaultStepStartStates(steps),

--- a/src/framework/execution/__tests__/dependencyGraph.test.ts
+++ b/src/framework/execution/__tests__/dependencyGraph.test.ts
@@ -29,9 +29,7 @@ import { Entity, Relationship } from '../../types';
 
 jest.mock('fs');
 
-afterEach(() => {
-  vol.reset();
-});
+afterEach(() => vol.reset());
 
 const executionContext: IntegrationExecutionContext = {
   logger: createIntegrationLogger({
@@ -162,7 +160,7 @@ describe('executeStepDependencyGraph', () => {
     });
   });
 
-  test.only("waits for all of a steps's dependencies to complete prior to executing", async () => {
+  test("waits for all of a steps's dependencies to complete prior to executing", async () => {
     let resolveA;
     const spyA = jest.fn(() => {
       return new Promise((resolve) => {
@@ -170,10 +168,9 @@ describe('executeStepDependencyGraph', () => {
       });
     });
 
-    let resolveB;
     const spyB = jest.fn(() => {
       return new Promise((resolve) => {
-        resolveB = resolve;
+        // never resolve
       });
     });
 

--- a/src/framework/execution/types/step.ts
+++ b/src/framework/execution/types/step.ts
@@ -25,6 +25,7 @@ export enum IntegrationStepResultStatus {
   FAILURE = 'failure',
   PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE = 'partial_success_due_to_dependency_failure',
   DISABLED = 'disabled',
+  PENDING_EVALUATION = 'pending_evaluation',
 }
 
 export type IntegrationStep = IntegrationStepMetadata & {


### PR DESCRIPTION
This fixes an issue with steps being prematurely kicked off before previous steps have fully completed their work.