### PR TITLE
Write summary.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- A `summary.json` file containing information about steps results and partial
+  datasets is now written to the `.j1-integration` directory.
+
 ## 0.8.1 2020-04-22
 
 ### Fixed

--- a/src/__tests__/__fixtures__/instanceWithDependentSteps/.gitignore
+++ b/src/__tests__/__fixtures__/instanceWithDependentSteps/.gitignore
@@ -1,0 +1,1 @@
+.j1-integration

--- a/src/framework/execution/__tests__/executeIntegration.test.ts
+++ b/src/framework/execution/__tests__/executeIntegration.test.ts
@@ -237,8 +237,10 @@ test('clears out the storage directory prior to performing collection', async ()
 
   // should still have written data to disk
   const files = await fs.readdir(getRootStorageDirectory());
-  expect(files).toHaveLength(2);
-  expect(files).toEqual(expect.arrayContaining(['graph', 'index']));
+  expect(files).toHaveLength(3);
+  expect(files).toEqual(
+    expect.arrayContaining(['graph', 'index', 'summary.json']),
+  );
 
   // files should not exist any more
   await expect(fs.readFile(previousContentFilePath)).rejects.toThrow(/ENOENT/);

--- a/src/framework/execution/executeIntegration.ts
+++ b/src/framework/execution/executeIntegration.ts
@@ -69,10 +69,12 @@ async function executeIntegration(
     integrationStepResults,
   );
 
-  return {
+  const summary = {
     integrationStepResults,
     metadata: {
       partialDatasets,
     },
   };
+
+  return summary;
 }

--- a/src/framework/execution/executeIntegration.ts
+++ b/src/framework/execution/executeIntegration.ts
@@ -14,7 +14,7 @@ import {
   determinePartialDatasetsFromStepExecutionResults,
 } from './step';
 
-import { removeStorageDirectory } from '../../fileSystem';
+import { removeStorageDirectory, writeJsonToPath } from '../../fileSystem';
 
 export interface ExecuteIntegrationResult {
   integrationStepResults: IntegrationStepResult[];
@@ -75,6 +75,11 @@ async function executeIntegration(
       partialDatasets,
     },
   };
+
+  await writeJsonToPath({
+    path: 'summary.json',
+    data: summary,
+  });
 
   return summary;
 }


### PR DESCRIPTION
As described in the [partial datasets](https://github.com/JupiterOne/integration-sdk/blob/master/docs/development.md#letting-the-synchronizer-know-about-partial-datasets) section of the sdk docs, the metadata from the summary will be used when finalizing the synchronization job. Having the summary on disk is helpful when performing the `sync` command (which I may soon be doing a lot of).