### PR TITLE
NO-TICKET - add mutateRequest function to change the request object preflight.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added `mutateRequest` function to recording to allow mutating the
+  `PollyRequest` object pre-flight.
+
+### Fixed
+
 ## 0.9.0 2020-04-23
 
 ### Added


### PR DESCRIPTION
The root of the issue is that a post body sent that is gunzipped won't get persisted correctly to the `.har` files because of this:
https://github.com/Netflix/pollyjs/blob/master/packages/%40pollyjs/persister/src/har/request.js#L42

The value of the `request.body` can't be changed post flight, because the object it inherits from is frozen once the request finishes so that the request can be uniquely identified.  Therefore I added in a function to change the value preflight...
https://github.com/Netflix/pollyjs/blob/master/packages/%40pollyjs/core/src/-private/http-base.js#L103

Example usage of this:

```
mutateRequest: (request) => {
    const contentEncoding = request.getHeader('content-encoding');
    if (contentEncoding === 'gzip') {
      const unzippedBody = zlib.unzipSync(request.body);
      request.body = unzippedBody.toString();
      request.setHeader('content-length', unzippedBody.byteLength);
      request.removeHeader('content-encoding');
    }
}
```