### PR TITLE
Allowing source objects to have null/undefined properties

### DIFF
--- a/src/framework/data/__tests__/createIntegrationEntity.test.ts
+++ b/src/framework/data/__tests__/createIntegrationEntity.test.ts
@@ -240,4 +240,31 @@ describe('createIntegrationEntity', () => {
       })._rawData,
     ).toEqual([]);
   });
+
+  test.each([null, undefined])(
+    'allow entities with %s properties to be created',
+    (value) => {
+      const entity = createIntegrationEntity({
+        entityData: {
+          assign: networkAssigns,
+          source: {
+            ...networkSourceData,
+            status: value,
+            createdOn: value,
+          },
+        },
+      });
+
+      const { rawData } = entity._rawData[0];
+
+      expect(rawData).toHaveProperty('status');
+      expect(rawData).toHaveProperty('createdOn');
+      expect(rawData).toEqual(
+        expect.objectContaining({
+          createdOn: value,
+          status: value,
+        }),
+      );
+    },
+  );
 });

--- a/src/framework/data/createIntegrationEntity.ts
+++ b/src/framework/data/createIntegrationEntity.ts
@@ -202,7 +202,8 @@ function whitelistedProviderData(
   const whitelistedProviderData: ProviderSourceData = {};
   const schemaProperties = schemaWhitelistedPropertyNames(_class);
   for (const e of Object.entries(source)) {
-    if (schemaProperties.includes(e[0])) {
+    const hasValue = e[1] !== null && e[1] !== undefined;
+    if (hasValue && schemaProperties.includes(e[0])) {
       whitelistedProviderData[e[0]] = e[1];
     }
   }

--- a/src/framework/data/createIntegrationEntity.ts
+++ b/src/framework/data/createIntegrationEntity.ts
@@ -201,10 +201,9 @@ function whitelistedProviderData(
 ): Omit<ProviderSourceData, 'tags'> {
   const whitelistedProviderData: ProviderSourceData = {};
   const schemaProperties = schemaWhitelistedPropertyNames(_class);
-  for (const e of Object.entries(source)) {
-    const hasValue = e[1] !== null && e[1] !== undefined;
-    if (hasValue && schemaProperties.includes(e[0])) {
-      whitelistedProviderData[e[0]] = e[1];
+  for (const [key, value] of Object.entries(source)) {
+    if (value != null && schemaProperties.includes(key)) {
+      whitelistedProviderData[key] = value;
     }
   }
   return whitelistedProviderData;


### PR DESCRIPTION
@aiwilliams and I noticed that when properties that line up with https://github.com/JupiterOne/data-model/tree/master/src/schemas are null they cause an exception to be thrown when calling createIntegrationEntity. This fix removes those properties from the whitelist of properties to be validated against the schema, but still allows those properties to be written to the entity created.