### PR TITLE
Allow external instance execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to
 
 - Added `sync` command to cli for synchronizing collected data with the
   JupiterOne graph.
+- Exporting `loadConfig()`, `executeIntegrationInstance()`, and
+  `createIntegrationLogger()` to allow for setup and execution with alternative,
+  non-generated local configuration.
 
 ### Fixed
 

--- a/src/framework/execution/__tests__/executeIntegration.test.ts
+++ b/src/framework/execution/__tests__/executeIntegration.test.ts
@@ -1,18 +1,23 @@
-import path from 'path';
 import { promises as fs } from 'fs';
 import { vol } from 'memfs';
-
-import {
-  IntegrationExecutionContext,
-  IntegrationStepResultStatus,
-} from '../types';
-import {
-  ExecuteIntegrationResult,
-  executeIntegrationLocally,
-} from '../executeIntegration';
-import { LOCAL_INTEGRATION_INSTANCE } from '../instance';
+import path from 'path';
 
 import { getRootStorageDirectory, readJsonFromPath } from '../../../fileSystem';
+import {
+  executeIntegrationInstance,
+  executeIntegrationLocally,
+  ExecuteIntegrationResult,
+} from '../executeIntegration';
+import { LOCAL_INTEGRATION_INSTANCE } from '../instance';
+import { createIntegrationLogger } from '../logger';
+import {
+  IntegrationExecutionContext,
+  IntegrationInstance,
+  IntegrationInvocationConfig,
+  IntegrationLogger,
+  IntegrationStepResultStatus,
+  InvocationValidationFunction,
+} from '../types';
 
 jest.mock('fs');
 
@@ -20,279 +25,318 @@ afterEach(() => {
   vol.reset();
 });
 
-test('executes validator function if provided in config', async () => {
-  const validate = jest.fn();
+describe('executeIntegrationInstance', () => {
+  let validate: InvocationValidationFunction;
+  let instance: IntegrationInstance;
+  let invocationConfig: IntegrationInvocationConfig;
+  let logger: IntegrationLogger;
 
-  await executeIntegrationLocally({
-    validateInvocation: validate,
-    integrationSteps: [],
+  const execute = () =>
+    executeIntegrationInstance(logger, instance, invocationConfig);
+
+  beforeEach(() => {
+    validate = jest.fn();
+
+    instance = LOCAL_INTEGRATION_INSTANCE;
+
+    invocationConfig = {
+      validateInvocation: validate,
+      integrationSteps: [],
+    };
+
+    logger = createIntegrationLogger({
+      name: 'integration-name',
+      invocationConfig,
+    });
   });
 
-  const expectedContext: IntegrationExecutionContext = {
-    instance: LOCAL_INTEGRATION_INSTANCE,
-    logger: expect.any(jest.requireActual('bunyan')),
-  };
+  test('executes validator function if provided in config', async () => {
+    await execute();
 
-  expect(validate).toHaveBeenCalledWith(expectedContext);
-});
+    const expectedContext: IntegrationExecutionContext = {
+      instance,
+      logger,
+    };
 
-test('returns integration step results and metadata about partial datasets', async () => {
-  const validate = jest.fn();
-
-  const result = await executeIntegrationLocally({
-    validateInvocation: validate,
-    integrationSteps: [
-      {
-        id: 'my-step',
-        name: 'My awesome step',
-        types: ['test'],
-        executionHandler: jest.fn(),
-      },
-    ],
+    expect(validate).toHaveBeenCalledWith(expectedContext);
   });
 
-  expect(result).toEqual({
-    integrationStepResults: [
-      {
-        id: 'my-step',
-        name: 'My awesome step',
-        types: ['test'],
-        status: IntegrationStepResultStatus.SUCCESS,
-      },
-    ],
-    metadata: {
-      partialDatasets: {
-        types: [],
-      },
-    },
-  });
-});
+  test('returns integration step results and metadata about partial datasets', async () => {
+    invocationConfig = {
+      ...invocationConfig,
+      integrationSteps: [
+        {
+          id: 'my-step',
+          name: 'My awesome step',
+          types: ['test'],
+          executionHandler: jest.fn(),
+        },
+      ],
+    };
 
-test('populates partialDatasets type for failed steps', async () => {
-  const validate = jest.fn();
-
-  const result = await executeIntegrationLocally({
-    validateInvocation: validate,
-    integrationSteps: [
-      {
-        id: 'my-step',
-        name: 'My awesome step',
-        types: ['test'],
-        executionHandler: jest
-          .fn()
-          .mockRejectedValue(new Error('something broke')),
-      },
-    ],
-  });
-
-  expect(result).toEqual({
-    integrationStepResults: [
-      {
-        id: 'my-step',
-        name: 'My awesome step',
-        types: ['test'],
-        status: IntegrationStepResultStatus.FAILURE,
-      },
-    ],
-    metadata: {
-      partialDatasets: {
-        types: ['test'],
-      },
-    },
-  });
-});
-
-test('includes types for partially successful steps steps in partial datasets', async () => {
-  const validate = jest.fn();
-
-  const result = await executeIntegrationLocally({
-    validateInvocation: validate,
-    integrationSteps: [
-      {
-        id: 'my-step-a',
-        name: 'My awesome step',
-        types: ['test_a'],
-        executionHandler: jest
-          .fn()
-          .mockRejectedValue(new Error('something broke')),
-      },
-      {
-        id: 'my-step-b',
-        name: 'My awesome step',
-        types: ['test_b'],
-        dependsOn: ['my-step-a'],
-        executionHandler: jest.fn(),
-      },
-    ],
-  });
-
-  expect(result).toEqual({
-    integrationStepResults: [
-      {
-        id: 'my-step-a',
-        name: 'My awesome step',
-        types: ['test_a'],
-        status: IntegrationStepResultStatus.FAILURE,
-      },
-      {
-        id: 'my-step-b',
-        name: 'My awesome step',
-        types: ['test_b'],
-        dependsOn: ['my-step-a'],
-        status:
-          IntegrationStepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE,
-      },
-    ],
-    metadata: {
-      partialDatasets: {
-        types: ['test_a', 'test_b'],
-      },
-    },
-  });
-});
-
-test('does not include partial data sets for disabled steps', async () => {
-  const validate = jest.fn();
-
-  const result = await executeIntegrationLocally({
-    validateInvocation: validate,
-    getStepStartStates: () => ({
-      'my-step-b': { disabled: true },
-      'my-step-a': { disabled: false },
-    }),
-    integrationSteps: [
-      {
-        id: 'my-step-a',
-        name: 'My awesome step',
-        types: ['test_a'],
-        executionHandler: jest
-          .fn()
-          .mockRejectedValue(new Error('something broke')),
-      },
-      {
-        id: 'my-step-b',
-        name: 'My awesome step',
-        types: ['test_b'],
-        executionHandler: jest.fn(),
-      },
-    ],
-  });
-
-  expect(result).toEqual({
-    integrationStepResults: [
-      {
-        id: 'my-step-a',
-        name: 'My awesome step',
-        types: ['test_a'],
-        status: IntegrationStepResultStatus.FAILURE,
-      },
-      {
-        id: 'my-step-b',
-        name: 'My awesome step',
-        types: ['test_b'],
-        status: IntegrationStepResultStatus.DISABLED,
-      },
-    ],
-    metadata: {
-      partialDatasets: {
-        types: ['test_a'],
-      },
-    },
-  });
-});
-
-test('clears out the storage directory prior to performing collection', async () => {
-  const previousContentFilePath = path.resolve(
-    getRootStorageDirectory(),
-    'graph',
-    'my-test',
-    'someFile.json',
-  );
-
-  vol.fromJSON({
-    [previousContentFilePath]: '{ "entities": [] }',
-  });
-
-  await executeIntegrationLocally({
-    integrationSteps: [
-      {
-        id: 'my-step',
-        name: 'My awesome step',
-        types: ['test'],
-        async executionHandler({ jobState }) {
-          await jobState.addEntities([
-            {
-              _key: 'test',
-              _type: 'test',
-              _class: 'Test',
-            },
-          ]);
+    await expect(execute()).resolves.toEqual({
+      integrationStepResults: [
+        {
+          id: 'my-step',
+          name: 'My awesome step',
+          types: ['test'],
+          status: IntegrationStepResultStatus.SUCCESS,
+        },
+      ],
+      metadata: {
+        partialDatasets: {
+          types: [],
         },
       },
-    ],
+    });
   });
 
-  // file should no longer exist
-  await expect(fs.readFile(previousContentFilePath)).rejects.toThrow(/ENOENT/);
+  test('populates partialDatasets type for failed steps', async () => {
+    invocationConfig = {
+      ...invocationConfig,
+      integrationSteps: [
+        {
+          id: 'my-step',
+          name: 'My awesome step',
+          types: ['test'],
+          executionHandler: jest
+            .fn()
+            .mockRejectedValue(new Error('something broke')),
+        },
+      ],
+    };
 
-  // should still have written data to disk
-  const files = await fs.readdir(getRootStorageDirectory());
-  expect(files).toHaveLength(3);
-  expect(files).toEqual(
-    expect.arrayContaining(['graph', 'index', 'summary.json']),
-  );
+    await expect(execute()).resolves.toEqual({
+      integrationStepResults: [
+        {
+          id: 'my-step',
+          name: 'My awesome step',
+          types: ['test'],
+          status: IntegrationStepResultStatus.FAILURE,
+        },
+      ],
+      metadata: {
+        partialDatasets: {
+          types: ['test'],
+        },
+      },
+    });
+  });
 
-  // files should not exist any more
-  await expect(fs.readFile(previousContentFilePath)).rejects.toThrow(/ENOENT/);
+  test('includes types for partially successful steps steps in partial datasets', async () => {
+    invocationConfig = {
+      ...invocationConfig,
+      integrationSteps: [
+        {
+          id: 'my-step-a',
+          name: 'My awesome step',
+          types: ['test_a'],
+          executionHandler: jest
+            .fn()
+            .mockRejectedValue(new Error('something broke')),
+        },
+        {
+          id: 'my-step-b',
+          name: 'My awesome step',
+          types: ['test_b'],
+          dependsOn: ['my-step-a'],
+          executionHandler: jest.fn(),
+        },
+      ],
+    };
+
+    await expect(execute()).resolves.toEqual({
+      integrationStepResults: [
+        {
+          id: 'my-step-a',
+          name: 'My awesome step',
+          types: ['test_a'],
+          status: IntegrationStepResultStatus.FAILURE,
+        },
+        {
+          id: 'my-step-b',
+          name: 'My awesome step',
+          types: ['test_b'],
+          dependsOn: ['my-step-a'],
+          status:
+            IntegrationStepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE,
+        },
+      ],
+      metadata: {
+        partialDatasets: {
+          types: ['test_a', 'test_b'],
+        },
+      },
+    });
+  });
+
+  test('does not include partial data sets for disabled steps', async () => {
+    invocationConfig = {
+      ...invocationConfig,
+      getStepStartStates: () => ({
+        'my-step-b': { disabled: true },
+        'my-step-a': { disabled: false },
+      }),
+      integrationSteps: [
+        {
+          id: 'my-step-a',
+          name: 'My awesome step',
+          types: ['test_a'],
+          executionHandler: jest
+            .fn()
+            .mockRejectedValue(new Error('something broke')),
+        },
+        {
+          id: 'my-step-b',
+          name: 'My awesome step',
+          types: ['test_b'],
+          executionHandler: jest.fn(),
+        },
+      ],
+    };
+
+    await expect(execute()).resolves.toEqual({
+      integrationStepResults: [
+        {
+          id: 'my-step-a',
+          name: 'My awesome step',
+          types: ['test_a'],
+          status: IntegrationStepResultStatus.FAILURE,
+        },
+        {
+          id: 'my-step-b',
+          name: 'My awesome step',
+          types: ['test_b'],
+          status: IntegrationStepResultStatus.DISABLED,
+        },
+      ],
+      metadata: {
+        partialDatasets: {
+          types: ['test_a'],
+        },
+      },
+    });
+  });
+
+  test('clears out the storage directory prior to performing collection', async () => {
+    const previousContentFilePath = path.resolve(
+      getRootStorageDirectory(),
+      'graph',
+      'my-test',
+      'someFile.json',
+    );
+
+    vol.fromJSON({
+      [previousContentFilePath]: '{ "entities": [] }',
+    });
+
+    invocationConfig = {
+      ...invocationConfig,
+      integrationSteps: [
+        {
+          id: 'my-step',
+          name: 'My awesome step',
+          types: ['test'],
+          async executionHandler({ jobState }) {
+            await jobState.addEntities([
+              {
+                _key: 'test',
+                _type: 'test',
+                _class: 'Test',
+              },
+            ]);
+          },
+        },
+      ],
+    };
+
+    await execute();
+
+    // file should no longer exist
+    await expect(fs.readFile(previousContentFilePath)).rejects.toThrow(
+      /ENOENT/,
+    );
+
+    // should still have written data to disk
+    const files = await fs.readdir(getRootStorageDirectory());
+    expect(files).toHaveLength(3);
+    expect(files).toEqual(
+      expect.arrayContaining(['graph', 'index', 'summary.json']),
+    );
+
+    // files should not exist any more
+    await expect(fs.readFile(previousContentFilePath)).rejects.toThrow(
+      /ENOENT/,
+    );
+  });
+
+  test('writes results to summary.json in storage directory', async () => {
+    invocationConfig = {
+      ...invocationConfig,
+      integrationSteps: [
+        {
+          id: 'my-step',
+          name: 'My awesome step',
+          types: ['test'],
+          executionHandler: jest.fn(),
+        },
+        {
+          id: 'my-step-2',
+          name: 'My awesome second step',
+          types: ['test_2'],
+          executionHandler: jest
+            .fn()
+            .mockRejectedValue(new Error('something went wrong')),
+        },
+      ],
+    };
+
+    const expectedResults = {
+      integrationStepResults: [
+        {
+          id: 'my-step',
+          name: 'My awesome step',
+          types: ['test'],
+          status: IntegrationStepResultStatus.SUCCESS,
+        },
+        {
+          id: 'my-step-2',
+          name: 'My awesome second step',
+          types: ['test_2'],
+          status: IntegrationStepResultStatus.FAILURE,
+        },
+      ],
+      metadata: {
+        partialDatasets: {
+          types: ['test_2'],
+        },
+      },
+    };
+
+    await expect(execute()).resolves.toEqual(expectedResults);
+
+    const writtenSummary = await readJsonFromPath<ExecuteIntegrationResult>(
+      path.resolve(getRootStorageDirectory(), 'summary.json'),
+    );
+
+    expect(writtenSummary).toEqual(expectedResults);
+  });
 });
 
-test('writes results to summary.json in storage directory', async () => {
-  const result = await executeIntegrationLocally({
-    integrationSteps: [
-      {
-        id: 'my-step',
-        name: 'My awesome step',
-        types: ['test'],
-        executionHandler: jest.fn(),
-      },
-      {
-        id: 'my-step-2',
-        name: 'My awesome second step',
-        types: ['test_2'],
-        executionHandler: jest
-          .fn()
-          .mockRejectedValue(new Error('something went wrong')),
-      },
-    ],
+describe('executeIntegrationLocally', () => {
+  test('provides generated logger and instance', async () => {
+    const validate = jest.fn();
+
+    await executeIntegrationLocally({
+      validateInvocation: validate,
+      integrationSteps: [],
+    });
+
+    const expectedContext: IntegrationExecutionContext = {
+      instance: LOCAL_INTEGRATION_INSTANCE,
+      logger: expect.any(jest.requireActual('bunyan')),
+    };
+
+    expect(validate).toHaveBeenCalledWith(expectedContext);
   });
-
-  const expectedResults = {
-    integrationStepResults: [
-      {
-        id: 'my-step',
-        name: 'My awesome step',
-        types: ['test'],
-        status: IntegrationStepResultStatus.SUCCESS,
-      },
-      {
-        id: 'my-step-2',
-        name: 'My awesome second step',
-        types: ['test_2'],
-        status: IntegrationStepResultStatus.FAILURE,
-      },
-    ],
-    metadata: {
-      partialDatasets: {
-        types: ['test_2'],
-      },
-    },
-  };
-
-  expect(result).toEqual(expectedResults);
-
-  const writtenSummary = await readJsonFromPath<ExecuteIntegrationResult>(
-    path.resolve(getRootStorageDirectory(), 'summary.json'),
-  );
-
-  expect(writtenSummary).toEqual(expectedResults);
 });

--- a/src/framework/execution/executeIntegration.ts
+++ b/src/framework/execution/executeIntegration.ts
@@ -1,20 +1,19 @@
+import { removeStorageDirectory, writeJsonToPath } from '../../fileSystem';
+import { createIntegrationInstanceForLocalExecution } from './instance';
+import { createIntegrationLogger } from './logger';
 import {
-  IntegrationInvocationConfig,
+  determinePartialDatasetsFromStepExecutionResults,
+  executeSteps,
+  getDefaultStepStartStates,
+} from './step';
+import {
   IntegrationExecutionContext,
+  IntegrationInstance,
+  IntegrationInvocationConfig,
+  IntegrationLogger,
   IntegrationStepResult,
   PartialDatasets,
 } from './types';
-
-import { createIntegrationLogger } from './logger';
-import { createIntegrationInstanceForLocalExecution } from './instance';
-
-import {
-  executeSteps,
-  getDefaultStepStartStates,
-  determinePartialDatasetsFromStepExecutionResults,
-} from './step';
-
-import { removeStorageDirectory, writeJsonToPath } from '../../fileSystem';
 
 export interface ExecuteIntegrationResult {
   integrationStepResults: IntegrationStepResult[];
@@ -24,23 +23,36 @@ export interface ExecuteIntegrationResult {
 }
 
 /**
- * Starts local execution of an integration
+ * Starts execution of an integration instance generated from local environment
+ * variables.
  */
 export function executeIntegrationLocally(config: IntegrationInvocationConfig) {
-  const logger = createIntegrationLogger({
-    name: 'Local',
-    invocationConfig: config,
-    pretty: true,
-  });
+  return executeIntegrationInstance(
+    createIntegrationLogger({
+      name: 'Local',
+      invocationConfig: config,
+      pretty: true,
+    }),
+    createIntegrationInstanceForLocalExecution(config),
+    config,
+  );
+}
 
-  const instance = createIntegrationInstanceForLocalExecution(config);
-
-  const context: IntegrationExecutionContext = {
-    instance,
-    logger,
-  };
-
-  return executeIntegration(context, config);
+/**
+ * Starts execution of an integration instance.
+ */
+export async function executeIntegrationInstance(
+  logger: IntegrationLogger,
+  instance: IntegrationInstance,
+  config: IntegrationInvocationConfig,
+): Promise<ExecuteIntegrationResult> {
+  return executeIntegration(
+    {
+      instance,
+      logger,
+    },
+    config,
+  );
 }
 
 /**

--- a/src/framework/execution/index.ts
+++ b/src/framework/execution/index.ts
@@ -1,3 +1,5 @@
 export * from './executeIntegration';
 export * from './types';
 export * from './error';
+
+export { createIntegrationLogger } from './logger';

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -1,5 +1,8 @@
+export * from '@jupiterone/data-model';
+
 export * from './data';
 export * from './execution';
 export * from './visualization';
 export * from './types';
-export * from '@jupiterone/data-model';
+
+export { loadConfig } from './config';


### PR DESCRIPTION
Provides ability to execute an instance without local, generated input. This does not address some other necessary changes, such as `loadConfig("node_module/@jupiterone/graph-trend-micro/dist")`, or `syncronize(...)` and `finalize(...)` with different J1 API clients.