### PR TITLE
0.16.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "src/framework/index.js",
   "types": "src/framework/index.d.ts",


### PR DESCRIPTION
I already updated the `CHANGELOG.md` for `v0.16.0` (which I shouldn't have done) so I don't need to update it again.

This was the `CHANGELOG.md` entry:

```
## 0.16.0 2020-04-30

### Added

- Added support for `yarn autobuild` command to make it easier to build and link
  `@lifeomic/integration-sdk` into other projects.
- Add `dotenv-expand` which allows expansion of `${...}` variables in `.env`
  file.
- Add **Integration SDK Development** section to `README.md`
```