### PR TITLE
Fix template, replace test run in pre-push

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   hooks: {
     'pre-commit': 'lint-staged',
-    'pre-push': 'yarn build',
+    'pre-push': 'yarn test && yarn build',
   },
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Template missing necessary publish build.
+
 ## 0.16.0 2020-04-30
 
 ### Added

--- a/template/.huskyrc
+++ b/template/.huskyrc
@@ -1,5 +1,6 @@
 {
   "hooks": {
-    "pre-commit": "lint-staged"
+    "pre-commit": "lint-staged",
+    "pre-push": "yarn build"
   }
 }

--- a/template/package.json
+++ b/template/package.json
@@ -18,7 +18,8 @@
     "test": "jest --passWithNoTests",
     "test:ci": "yarn lint && yarn type-check && yarn test",
     "prebuild": "yarn test:ci",
-    "build": "tsc -p tsconfig.dist.json --declaration"
+    "build": "tsc -p tsconfig.dist.json --declaration",
+    "prepublishOnly": "yarn build"
   },
   "dependencies": {
     "@jupiterone/integration-sdk": "^0.1.0"


### PR DESCRIPTION
The `yarn build` used to run the tests in `prebuild`, but that was lost with `autobuild` changes in last release.