### PR TITLE
Add IntegrationConfigLoadError type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `IntegrationConfigLoadError`, to be thrown when there is a configuration load
+  error. This can be used by non-local execution environments that load
+  configuration from somewhere special.
+
 ## 0.16.0 2020-04-30
 
 ### Added

--- a/src/framework/execution/error.ts
+++ b/src/framework/execution/error.ts
@@ -17,11 +17,19 @@ export class IntegrationLocalConfigFieldTypeMismatch extends IntegrationError {
     });
   }
 }
+export class IntegrationConfigLoadError extends IntegrationError {
+  constructor(message: string) {
+    super({
+      code: 'CONFIG_LOAD_ERROR',
+      message,
+    });
+  }
+}
 
 export class IntegrationConfigValidationError extends IntegrationError {
   constructor(message: string) {
     super({
-      code: 'LOCAL_CONFIG_FIELD_TYPE_MISMATCH',
+      code: 'CONFIG_FIELD_TYPE_MISMATCH',
       message,
     });
   }


### PR DESCRIPTION
This will be used by the managed integration environment to complain when it cannot load a config.