### PR TITLE
Remove usage of jest.resetModules and require.cache access

### DIFF
--- a/src/cli/__tests__/cli.test.ts
+++ b/src/cli/__tests__/cli.test.ts
@@ -10,11 +10,6 @@ const fs = nodeFs.promises;
 jest.mock('../../log');
 
 afterEach(() => {
-  // clear require cache
-  Object.keys(require.cache).forEach((modulePath) => {
-    delete require.cache[modulePath];
-  });
-
   delete process.env.MY_CONFIG;
 });
 

--- a/src/framework/__tests__/config.test.ts
+++ b/src/framework/__tests__/config.test.ts
@@ -17,7 +17,6 @@ import {
 jest.mock('../../log');
 
 afterEach(() => {
-  jest.resetModules();
   restoreProjectStructure();
 });
 


### PR DESCRIPTION
Started seeing some warnings about require.cache access while doing other so decided to address this rnrq. I originally added the `require.cache` clearing and `jest.resetModules` because I wanted to be cautious in tests when performing fixture loading, but this isn't really an issue.