### PR TITLE
Add step event publishing functions to logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Automatic event logging around steps (start, end, and failure).
+
 ## 0.17.0 2020-05-01
 
 ### Added

--- a/src/cli/__tests__/util/synchronization.ts
+++ b/src/cli/__tests__/util/synchronization.ts
@@ -27,6 +27,13 @@ export function setupSynchronizerApi({ polly, job, baseUrl }: SetupOptions) {
     });
 
   polly.server
+    .post(`${baseUrl}/persister/synchronization/jobs/${job.id}/events`)
+    .intercept((req, res) => {
+      allowCrossOrigin(req, res);
+      return res.status(200).json({});
+    });
+
+  polly.server
     .post(`${baseUrl}/persister/synchronization/jobs/${job.id}/relationships`)
     .intercept((req, res) => {
       allowCrossOrigin(req, res);

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -13,7 +13,8 @@ import {
   uploadCollectedData,
   finalizeSynchronization,
 } from '../../framework/synchronization';
-import { executeIntegrationLocally } from '../../framework/execution';
+import { executeIntegrationInstance } from '../../framework/execution';
+import { createIntegrationInstanceForLocalExecution } from '../../framework/execution/instance';
 
 export function run() {
   return createCommand('run')
@@ -48,11 +49,16 @@ export function run() {
         integrationInstanceId,
       });
 
-      const executionResults = await executeIntegrationLocally(
+      logger.registerSynchronizationJobContext(synchronizationContext);
+
+      const executionResults = await executeIntegrationInstance(
+        logger,
+        createIntegrationInstanceForLocalExecution(invocationConfig),
         invocationConfig,
       );
 
       log.displayExecutionResults(executionResults);
+
       await uploadCollectedData(synchronizationContext);
 
       const synchronizationResult = await finalizeSynchronization({

--- a/src/framework/execution/__tests__/dependencyGraph.test.ts
+++ b/src/framework/execution/__tests__/dependencyGraph.test.ts
@@ -556,8 +556,8 @@ describe('executeStepDependencyGraph', () => {
 
     expect(errorLogSpy).toHaveBeenCalledTimes(1);
     expect(errorLogSpy).toHaveBeenCalledWith(
-      error,
-      'Step failed to complete due to error.',
+      { step: 'a', err: error },
+      'Step "a" failed to complete due to error.',
     );
   });
 

--- a/src/framework/execution/__tests__/logger.test.ts
+++ b/src/framework/execution/__tests__/logger.test.ts
@@ -1,8 +1,14 @@
 import { Writable } from 'stream';
+import noop from 'lodash/noop';
 
 import { createIntegrationLogger } from '../logger';
 import Logger from 'bunyan';
-import { IntegrationInvocationConfig } from '../types';
+import { IntegrationInvocationConfig, IntegrationStep } from '../types';
+import {
+  SynchronizationJobContext,
+  SynchronizationJob,
+} from '../../synchronization';
+import { createApiClient } from '../../api';
 
 const invocationConfig = {} as IntegrationInvocationConfig;
 const name = 'integration-logger';
@@ -190,6 +196,107 @@ describe('createIntegrationLogger', () => {
         masked: '****cret',
         unmasked: 'this is clear',
       });
+    });
+  });
+});
+
+describe('step event publishing', () => {
+  test('writes logs for stepEnd, stepStart, and stepFailure events', () => {
+    const logger = createIntegrationLogger({ name, invocationConfig });
+
+    const infoSpy = jest.spyOn(logger, 'info');
+    const errorSpy = jest.spyOn(logger, 'error');
+
+    const step: IntegrationStep = {
+      id: 'a',
+      name: 'Mochi',
+      types: [],
+      dependsOn: [],
+      executionHandler: jest.fn(),
+    };
+
+    logger.stepStart(step);
+    logger.stepSuccess(step);
+
+    expect(infoSpy).toHaveBeenCalledTimes(2);
+    expect(infoSpy).toHaveBeenNthCalledWith(
+      1,
+      {
+        step: step.id,
+      },
+      `Starting step "Mochi"...`,
+    );
+    expect(infoSpy).toHaveBeenNthCalledWith(
+      2,
+      {
+        step: step.id,
+      },
+      `Completed step "Mochi".`,
+    );
+
+    const error = new Error('ripperoni');
+    logger.stepFailure(step, error);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenNthCalledWith(
+      1,
+      {
+        err: error,
+        step: step.id,
+      },
+      `Step "Mochi" failed to complete due to error.`,
+    );
+  });
+
+  test('posts events via api client if synchronizationContext is registered', async () => {
+    const logger = createIntegrationLogger({ name, invocationConfig });
+    const context: SynchronizationJobContext = {
+      logger,
+      job: { id: 'test-job-id' } as SynchronizationJob,
+      apiClient: createApiClient({
+        apiBaseUrl: 'https://api.us.jupiterone.io',
+        account: 'mocheronis',
+      }),
+    };
+
+    logger.registerSynchronizationJobContext(context);
+
+    const postSpy = jest
+      .spyOn(context.apiClient, 'post')
+      .mockImplementation(noop as any);
+
+    const step: IntegrationStep = {
+      id: 'a',
+      name: 'Mochi',
+      types: [],
+      dependsOn: [],
+      executionHandler: jest.fn(),
+    };
+
+    logger.stepStart(step);
+    logger.stepSuccess(step);
+    const error = new Error('ripperoni');
+    logger.stepFailure(step, error);
+
+    await logger.flush();
+
+    const expectedEventsUrl =
+      '/persister/synchronization/jobs/test-job-id/events';
+
+    expect(postSpy).toHaveBeenCalledTimes(3);
+    expect(postSpy).toHaveBeenNthCalledWith(1, expectedEventsUrl, {
+      events: [{ name: 'step-start', description: 'Starting step "Mochi"...' }],
+    });
+    expect(postSpy).toHaveBeenNthCalledWith(2, expectedEventsUrl, {
+      events: [{ name: 'step-end', description: 'Completed step "Mochi".' }],
+    });
+    expect(postSpy).toHaveBeenNthCalledWith(3, expectedEventsUrl, {
+      events: [
+        {
+          name: 'step-failure',
+          description: 'Step "Mochi" failed to complete due to error.',
+        },
+      ],
     });
   });
 });

--- a/src/framework/execution/dependencyGraph.ts
+++ b/src/framework/execution/dependencyGraph.ts
@@ -198,13 +198,13 @@ export function executeStepDependencyGraph(
         graphObjectStore,
       );
 
-      context.logger.info(`Executing step "${step.name}"`);
+      context.logger.stepStart(step);
 
       let status: IntegrationStepResultStatus;
 
       try {
         await step.executionHandler(context);
-        context.logger.info('Step has completed successfully.');
+        context.logger.stepSuccess(step);
 
         if (stepHasDependencyFailure(step)) {
           status =
@@ -213,7 +213,7 @@ export function executeStepDependencyGraph(
           status = IntegrationStepResultStatus.SUCCESS;
         }
       } catch (err) {
-        context.logger.error(err, 'Step failed to complete due to error.');
+        context.logger.stepFailure(step, err);
         status = IntegrationStepResultStatus.FAILURE;
       }
 

--- a/src/framework/execution/executeIntegration.ts
+++ b/src/framework/execution/executeIntegration.ts
@@ -46,13 +46,17 @@ export async function executeIntegrationInstance(
   instance: IntegrationInstance,
   config: IntegrationInvocationConfig,
 ): Promise<ExecuteIntegrationResult> {
-  return executeIntegration(
+  const result = await executeIntegration(
     {
       instance,
       logger,
     },
     config,
   );
+
+  await logger.flush();
+
+  return result;
 }
 
 /**

--- a/src/framework/execution/types/logger.ts
+++ b/src/framework/execution/types/logger.ts
@@ -1,3 +1,6 @@
+import { IntegrationStep } from './step';
+import { SynchronizationJobContext } from '../../synchronization';
+
 interface LogFunction {
   (...args: any[]): boolean | void;
 }
@@ -6,7 +9,11 @@ interface ChildLogFunction {
   (options: object): IntegrationLogger;
 }
 
-export interface IntegrationLogger {
+type StepLogFunction = (step: IntegrationStep) => void;
+type StepLogFunctionWithError = (step: IntegrationStep, err: Error) => void;
+
+interface BaseLogger {
+  // traditional functions for regular logging
   trace: LogFunction;
   debug: LogFunction;
   info: LogFunction;
@@ -14,4 +21,19 @@ export interface IntegrationLogger {
   error: LogFunction;
   fatal: LogFunction;
   child: ChildLogFunction;
+}
+
+export interface IntegrationLogger extends BaseLogger {
+  registerSynchronizationJobContext: (
+    context: SynchronizationJobContext,
+  ) => void;
+
+  // Special log functions used to publish events to j1
+  stepStart: StepLogFunction;
+  stepSuccess: StepLogFunction;
+  stepFailure: StepLogFunctionWithError;
+
+  // flushes the queue of work to ensure that
+  // all events have been published
+  flush: () => Promise<void>;
 }

--- a/src/framework/synchronization/index.ts
+++ b/src/framework/synchronization/index.ts
@@ -46,7 +46,7 @@ export async function synchronizeCollectedData(
   });
 }
 
-interface SynchronizationJobContext {
+export interface SynchronizationJobContext {
   apiClient: ApiClient;
   job: SynchronizationJob;
   logger: IntegrationLogger;

--- a/src/testing/__tests__/context.test.ts
+++ b/src/testing/__tests__/context.test.ts
@@ -12,6 +12,7 @@ import {
   createMockExecutionContext,
   createMockStepExecutionContext,
 } from '../context';
+import { noopAsync } from '../logger';
 
 /**
  * Ensure that both createMockExecutionContext and
@@ -33,12 +34,13 @@ import {
         const { logger } = createContext();
 
         Object.keys(logger).forEach((key) => {
-          if (key !== 'child') {
+          if (key !== 'child' && key !== 'flush') {
             expect(logger[key]).toEqual(noop);
           }
         });
 
         expect(logger.child({})).toEqual(logger);
+        expect(logger.flush).toEqual(noopAsync);
       });
 
       test('generates an execution context with the integration instance used for local development', () => {

--- a/src/testing/logger.ts
+++ b/src/testing/logger.ts
@@ -1,5 +1,6 @@
 import { IntegrationLogger } from '../framework';
 import noop from 'lodash/noop';
+export const noopAsync = () => Promise.resolve();
 
 export function createMockIntegrationLogger(): IntegrationLogger {
   const logger: IntegrationLogger = {
@@ -9,6 +10,11 @@ export function createMockIntegrationLogger(): IntegrationLogger {
     warn: noop,
     error: noop,
     fatal: noop,
+    registerSynchronizationJobContext: noop,
+    stepStart: noop,
+    stepSuccess: noop,
+    stepFailure: noop,
+    flush: noopAsync,
     child() {
       return this;
     },


### PR DESCRIPTION
As per, what we have in the [development document](https://github.com/JupiterOne/integration-sdk/blob/master/docs/development.md#logger) around logging, this felt like a good time to experiment with instrumenting the logger with new functions that perform both event publishing and traditional logging.