### PR TITLE
Abort synchronization job on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - An `errorCode`, `errorId`, and `reason` is now displayed in step failure
   events and logs.
 - Event logging around errors thrown in `validateInvocation` function.
+- Abort synchronization job when `run` and `sync` command fails.
 
 ### Changed
 

--- a/src/__tests__/__fixtures__/validationFailure/src/steps/fetchUsers.ts
+++ b/src/__tests__/__fixtures__/validationFailure/src/steps/fetchUsers.ts
@@ -1,0 +1,8 @@
+import noop from 'lodash/noop';
+
+export default {
+  id: 'fetch-users',
+  name: 'Fetch Users',
+  types: ['my_user'],
+  executionHandler: noop,
+};

--- a/src/__tests__/__fixtures__/validationFailure/src/validateInvocation.ts
+++ b/src/__tests__/__fixtures__/validationFailure/src/validateInvocation.ts
@@ -1,0 +1,5 @@
+import { IntegrationValidationError } from '../../../../framework';
+
+export default function validateInvocation() {
+  throw new IntegrationValidationError('Failed to access provider api');
+}

--- a/src/cli/__tests__/cli-run-failure.test.ts
+++ b/src/cli/__tests__/cli-run-failure.test.ts
@@ -1,0 +1,110 @@
+import { mocked } from 'ts-jest/utils';
+import { Polly } from '@pollyjs/core';
+import NodeHttpAdapter from '@pollyjs/adapter-node-http';
+import FSPersister from '@pollyjs/persister-fs';
+import jwt from 'jsonwebtoken';
+
+import { createCli } from '../index';
+import { loadProjectStructure } from '../../__tests__/loadProjectStructure';
+
+import {
+  generateSynchronizationJob,
+  setupSynchronizerApi,
+} from './util/synchronization';
+
+import { SynchronizationJobStatus } from '../../framework/synchronization';
+import { createIntegrationLogger as mockCreateIntegrationLogger } from '../../framework/execution/logger';
+
+import * as log from '../../log';
+
+jest.mock('../../log');
+jest.mock('../../framework/execution/logger');
+
+Polly.register(NodeHttpAdapter);
+Polly.register(FSPersister);
+
+const { createIntegrationLogger } = jest.requireActual(
+  '../../framework/execution/logger',
+);
+
+let polly: Polly;
+
+beforeEach(() => {
+  process.env.JUPITERONE_API_KEY = jwt.sign({ account: 'mochi' }, 'test');
+  loadProjectStructure('validationFailure');
+
+  polly = new Polly('run-cli-failure', {
+    adapters: ['node-http'],
+    persister: 'fs',
+    logging: false,
+    matchRequestsBy: {
+      headers: false,
+    },
+  });
+
+  mocked(mockCreateIntegrationLogger).mockReturnValue(
+    createIntegrationLogger({ name: 'test' }),
+  );
+
+  jest.spyOn(process, 'exit').mockImplementation((code: number | undefined) => {
+    throw new Error(`Process exited with code ${code}`);
+  });
+});
+
+afterEach(() => {
+  polly.disconnect();
+});
+
+test('aborts synchronization job if an error occurs', async () => {
+  const job = generateSynchronizationJob();
+
+  setupSynchronizerApi({ polly, job, baseUrl: 'https://api.us.jupiterone.io' });
+
+  await createCli().parseAsync([
+    'node',
+    'j1-integration',
+    'run',
+    '--integrationInstanceId',
+    'test',
+  ]);
+
+  expect(log.displaySynchronizationResults).toHaveBeenCalledTimes(1);
+  expect(log.displaySynchronizationResults).toHaveBeenCalledWith({
+    ...job,
+    status: SynchronizationJobStatus.ABORTED,
+  });
+});
+
+test('does not log errors that have been previously logged', async () => {
+  const job = generateSynchronizationJob();
+
+  setupSynchronizerApi({ polly, job, baseUrl: 'https://api.us.jupiterone.io' });
+
+  const logger = createIntegrationLogger({ name: 'test' });
+
+  const isHandledErrorSpy = jest.spyOn(logger, 'isHandledError');
+  const validationFailureSpy = jest.spyOn(logger, 'validationFailure');
+  const errorSpy = jest.spyOn(logger, 'error');
+
+  jest.spyOn(logger, 'child').mockReturnValue(logger);
+
+  mocked(mockCreateIntegrationLogger).mockReturnValue(logger);
+
+  await createCli().parseAsync([
+    'node',
+    'j1-integration',
+    'run',
+    '--integrationInstanceId',
+    'test',
+  ]);
+
+  expect(validationFailureSpy).toHaveBeenCalledTimes(1);
+
+  const loggedError = validationFailureSpy.mock.calls[0][0];
+
+  expect(isHandledErrorSpy).toHaveBeenCalledTimes(1);
+  expect(isHandledErrorSpy).toHaveBeenCalledWith(loggedError);
+  expect(isHandledErrorSpy).toHaveReturnedWith(true);
+
+  expect(errorSpy).toHaveBeenCalledTimes(1);
+});

--- a/src/cli/__tests__/cli-run.test.ts
+++ b/src/cli/__tests__/cli-run.test.ts
@@ -114,3 +114,25 @@ test('executes integration and performs upload', async () => {
     numRelationshipsUploaded: 1,
   });
 });
+
+test('aborts synchronization job if an error occurs', async () => {
+  // validation failure will cause synchronization to stop
+  loadProjectStructure('validationFailure');
+  const job = generateSynchronizationJob();
+
+  setupSynchronizerApi({ polly, job, baseUrl: 'https://api.us.jupiterone.io' });
+
+  await createCli().parseAsync([
+    'node',
+    'j1-integration',
+    'run',
+    '--integrationInstanceId',
+    'test',
+  ]);
+
+  expect(log.displaySynchronizationResults).toHaveBeenCalledTimes(1);
+  expect(log.displaySynchronizationResults).toHaveBeenCalledWith({
+    ...job,
+    status: SynchronizationJobStatus.ABORTED,
+  });
+});

--- a/src/cli/__tests__/cli-run.test.ts
+++ b/src/cli/__tests__/cli-run.test.ts
@@ -114,25 +114,3 @@ test('executes integration and performs upload', async () => {
     numRelationshipsUploaded: 1,
   });
 });
-
-test('aborts synchronization job if an error occurs', async () => {
-  // validation failure will cause synchronization to stop
-  loadProjectStructure('validationFailure');
-  const job = generateSynchronizationJob();
-
-  setupSynchronizerApi({ polly, job, baseUrl: 'https://api.us.jupiterone.io' });
-
-  await createCli().parseAsync([
-    'node',
-    'j1-integration',
-    'run',
-    '--integrationInstanceId',
-    'test',
-  ]);
-
-  expect(log.displaySynchronizationResults).toHaveBeenCalledTimes(1);
-  expect(log.displaySynchronizationResults).toHaveBeenCalledWith({
-    ...job,
-    status: SynchronizationJobStatus.ABORTED,
-  });
-});

--- a/src/cli/__tests__/util/synchronization.ts
+++ b/src/cli/__tests__/util/synchronization.ts
@@ -48,6 +48,14 @@ export function setupSynchronizerApi({ polly, job, baseUrl }: SetupOptions) {
       job.status = SynchronizationJobStatus.FINALIZE_PENDING;
       return res.status(200).json({ job });
     });
+
+  polly.server
+    .post(`${baseUrl}/persister/synchronization/jobs/${job.id}/abort`)
+    .intercept((req, res) => {
+      allowCrossOrigin(req, res);
+      job.status = SynchronizationJobStatus.ABORTED;
+      return res.status(200).json({ job });
+    });
 }
 
 function allowCrossOrigin(req, res) {

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -12,6 +12,7 @@ import {
   initiateSynchronization,
   uploadCollectedData,
   finalizeSynchronization,
+  abortSynchronization,
 } from '../../framework/synchronization';
 import { executeIntegrationInstance } from '../../framework/execution';
 import { createIntegrationInstanceForLocalExecution } from '../../framework/execution/instance';
@@ -51,24 +52,35 @@ export function run() {
 
       logger.registerSynchronizationJobContext(synchronizationContext);
 
-      const executionResults = await executeIntegrationInstance(
-        logger,
-        createIntegrationInstanceForLocalExecution(invocationConfig),
-        invocationConfig,
-        {
-          enableSchemaValidation: true,
-        },
-      );
+      try {
+        const executionResults = await executeIntegrationInstance(
+          logger,
+          createIntegrationInstanceForLocalExecution(invocationConfig),
+          invocationConfig,
+          {
+            enableSchemaValidation: true,
+          },
+        );
 
-      log.displayExecutionResults(executionResults);
+        log.displayExecutionResults(executionResults);
 
-      await uploadCollectedData(synchronizationContext);
+        await uploadCollectedData(synchronizationContext);
 
-      const synchronizationResult = await finalizeSynchronization({
-        ...synchronizationContext,
-        partialDatasets: executionResults.metadata.partialDatasets,
-      });
+        const synchronizationResult = await finalizeSynchronization({
+          ...synchronizationContext,
+          partialDatasets: executionResults.metadata.partialDatasets,
+        });
 
-      log.displaySynchronizationResults(synchronizationResult);
+        log.displaySynchronizationResults(synchronizationResult);
+      } catch (err) {
+        await logger.flush();
+
+        const abortResult = await abortSynchronization({
+          ...synchronizationContext,
+          reason: err.message,
+        });
+
+        log.displaySynchronizationResults(abortResult);
+      }
     });
 }

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -75,6 +75,13 @@ export function run() {
       } catch (err) {
         await logger.flush();
 
+        if (!logger.isHandledError(err)) {
+          logger.error(
+            err,
+            'Unexpected error occurred during integration run.',
+          );
+        }
+
         const abortResult = await abortSynchronization({
           ...synchronizationContext,
           reason: err.message,

--- a/src/framework/execution/types/logger.ts
+++ b/src/framework/execution/types/logger.ts
@@ -12,6 +12,7 @@ interface ChildLogFunction {
 type StepLogFunction = (step: IntegrationStep) => void;
 type StepLogFunctionWithError = (step: IntegrationStep, err: Error) => void;
 type ValidationLogFunction = (err: Error) => void;
+type IsHandledErrorFunction = (err: Error) => boolean;
 
 interface BaseLogger {
   // traditional functions for regular logging
@@ -28,6 +29,8 @@ export interface IntegrationLogger extends BaseLogger {
   registerSynchronizationJobContext: (
     context: SynchronizationJobContext,
   ) => void;
+
+  isHandledError: IsHandledErrorFunction;
 
   // Special log functions used to publish events to j1
   stepStart: StepLogFunction;

--- a/src/framework/synchronization/__tests__/index.test.ts
+++ b/src/framework/synchronization/__tests__/index.test.ts
@@ -8,6 +8,7 @@ import {
   uploadCollectedData,
   finalizeSynchronization,
   synchronizeCollectedData,
+  abortSynchronization,
 } from '../index';
 
 import { getApiBaseUrl, createApiClient } from '../../api';
@@ -153,6 +154,38 @@ describe('finalizeSynchronization', () => {
       `/persister/synchronization/jobs/${job.id}/finalize`,
       {
         partialDatasets,
+      },
+    );
+  });
+});
+
+describe('abortSynchronization', () => {
+  test('sends reason to payload', async () => {
+    loadProjectStructure('synchronization');
+
+    const job = generateSynchronizationJob();
+    const context = createTestContext();
+    const { apiClient } = context;
+
+    const postSpy = jest.spyOn(apiClient, 'post').mockResolvedValue({
+      data: {
+        job,
+      },
+    });
+
+    const returnedJob = await abortSynchronization({
+      ...context,
+      job,
+      reason: 'test',
+    });
+
+    expect(returnedJob).toEqual(job);
+
+    expect(postSpy).toHaveBeenCalledTimes(1);
+    expect(postSpy).toHaveBeenCalledWith(
+      `/persister/synchronization/jobs/${job.id}/abort`,
+      {
+        reason: 'test',
       },
     );
   });

--- a/src/framework/synchronization/index.ts
+++ b/src/framework/synchronization/index.ts
@@ -38,12 +38,22 @@ export async function synchronizeCollectedData(
 ): Promise<SynchronizationJob> {
   const jobContext = await initiateSynchronization(input);
 
-  await uploadCollectedData(jobContext);
+  try {
+    await uploadCollectedData(jobContext);
 
-  return await finalizeSynchronization({
-    ...jobContext,
-    partialDatasets: await getPartialDatasets(),
-  });
+    return await finalizeSynchronization({
+      ...jobContext,
+      partialDatasets: await getPartialDatasets(),
+    });
+  } catch (err) {
+    jobContext.logger.error(
+      err,
+      'Error occured while synchronizing collected data',
+    );
+
+    await abortSynchronization({ ...jobContext, reason: err.message });
+    throw err;
+  }
 }
 
 export interface SynchronizationJobContext {

--- a/src/framework/synchronization/index.ts
+++ b/src/framework/synchronization/index.ts
@@ -72,7 +72,6 @@ export async function initiateSynchronization({
     job = response.data.job;
   } catch (err) {
     const errorMessage = 'Error occurred while initiating synchronization job.';
-    logger.error(err, errorMessage);
     throw synchronizationApiError(err, errorMessage);
   }
 
@@ -179,4 +178,34 @@ async function uploadData<T extends UploadDataLookup, K extends keyof T>(
     },
     { concurrency: UPLOAD_CONCURRENCY },
   );
+}
+
+interface AbortSynchronizationInput extends SynchronizationJobContext {
+  reason?: string;
+}
+/**
+ * Aborts a synchronization job
+ */
+export async function abortSynchronization({
+  logger,
+  apiClient,
+  job,
+  reason,
+}: AbortSynchronizationInput) {
+  logger.info('Aborting synchronization job...');
+
+  let abortedJob: SynchronizationJob;
+
+  try {
+    const response = await apiClient.post(
+      `/persister/synchronization/jobs/${job.id}/abort`,
+      { reason },
+    );
+    abortedJob = response.data.job;
+  } catch (err) {
+    const errorMessage = 'Error occurred while aborting synchronization job.';
+    throw synchronizationApiError(err, errorMessage);
+  }
+
+  return abortedJob;
 }

--- a/src/framework/synchronization/index.ts
+++ b/src/framework/synchronization/index.ts
@@ -81,8 +81,10 @@ export async function initiateSynchronization({
 
     job = response.data.job;
   } catch (err) {
-    const errorMessage = 'Error occurred while initiating synchronization job.';
-    throw synchronizationApiError(err, errorMessage);
+    throw synchronizationApiError(
+      err,
+      'Error occurred while initiating synchronization job',
+    );
   }
 
   return {
@@ -122,9 +124,10 @@ export async function finalizeSynchronization({
     );
     finalizedJob = response.data.job;
   } catch (err) {
-    const errorMessage = 'Error occurred while finalizing synchronization job.';
-    logger.error(err, errorMessage);
-    throw synchronizationApiError(err, errorMessage);
+    throw synchronizationApiError(
+      err,
+      'Error occurred while finalizing synchronization job.',
+    );
   }
 
   return finalizedJob;
@@ -142,7 +145,6 @@ async function getPartialDatasets() {
  * Uploads data collected by the integration into the
  */
 export async function uploadCollectedData(context: SynchronizationJobContext) {
-  const { logger } = context;
   await walkDirectory({
     path: 'graph',
     async iteratee({ data }) {
@@ -157,9 +159,7 @@ export async function uploadCollectedData(context: SynchronizationJobContext) {
           await uploadData(context, 'relationships', parsedData.relationships);
         }
       } catch (err) {
-        const errorMessage = 'Error uploading collected data.';
-        logger.error(err, errorMessage);
-        throw synchronizationApiError(err, errorMessage);
+        throw synchronizationApiError(err, 'Error uploading collected data');
       }
     },
   });
@@ -213,8 +213,10 @@ export async function abortSynchronization({
     );
     abortedJob = response.data.job;
   } catch (err) {
-    const errorMessage = 'Error occurred while aborting synchronization job.';
-    throw synchronizationApiError(err, errorMessage);
+    throw synchronizationApiError(
+      err,
+      'Error occurred while aborting synchronization job',
+    );
   }
 
   return abortedJob;

--- a/src/testing/__tests__/context.test.ts
+++ b/src/testing/__tests__/context.test.ts
@@ -34,7 +34,7 @@ import { noopAsync } from '../logger';
         const { logger } = createContext();
 
         Object.keys(logger).forEach((key) => {
-          if (key !== 'child' && key !== 'flush') {
+          if (key !== 'child' && key !== 'flush' && key !== 'isHandledError') {
             expect(logger[key]).toEqual(noop);
           }
         });

--- a/src/testing/logger.ts
+++ b/src/testing/logger.ts
@@ -11,6 +11,7 @@ export function createMockIntegrationLogger(): IntegrationLogger {
     error: noop,
     fatal: noop,
     registerSynchronizationJobContext: noop,
+    isHandledError: () => false,
     stepStart: noop,
     stepSuccess: noop,
     stepFailure: noop,


### PR DESCRIPTION
I setup the logger to track previously logged errors so that we can avoid duplicate logging at the final `catch`. Mutating the error as it bubbled up felt a little dirty, so I set up tracking via a `Set`. I don't feel too strongly about any approach though.