### PR TITLE
Support loading invocation config from src/index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Support loading invocation configuration from `src/index`.
+
+### Deprecated
+
+- Deprecated convention style loading.
+
 ## 0.18.0 2020-05-01
 
 ### Added

--- a/src/__tests__/__fixtures__/indexFileEntrypoint/src/index.ts
+++ b/src/__tests__/__fixtures__/indexFileEntrypoint/src/index.ts
@@ -1,0 +1,33 @@
+import noop from 'lodash/noop';
+
+export const invocationConfig = {
+  instanceConfigFields: {
+    myConfig: {
+      mask: true,
+      type: 'boolean',
+    },
+  },
+  integrationSteps: [
+    {
+      id: 'fetch-accounts',
+      name: 'Fetch Accounts',
+      types: ['my_account'],
+      executionHandler: noop,
+    },
+    {
+      id: 'fetch-users',
+      name: 'Fetch Users',
+      types: ['my_user'],
+      executionHandler: noop,
+    },
+  ],
+  validateInvocation: noop,
+  getStepStartStates: () => ({
+    'fetch-accounts': {
+      disabled: false,
+    },
+    'fetch-users': {
+      disabled: false,
+    },
+  }),
+};

--- a/src/__tests__/__fixtures__/indexFileEntrypointFailure/src/index.ts
+++ b/src/__tests__/__fixtures__/indexFileEntrypointFailure/src/index.ts
@@ -1,0 +1,35 @@
+import noop from 'lodash/noop';
+
+// this fixture helps ensure that the
+// invocation config is read correctly
+export default {
+  instanceConfigFields: {
+    myConfig: {
+      mask: true,
+      type: 'boolean',
+    },
+  },
+  integrationSteps: [
+    {
+      id: 'fetch-accounts',
+      name: 'Fetch Accounts',
+      types: ['my_account'],
+      executionHandler: noop,
+    },
+    {
+      id: 'fetch-users',
+      name: 'Fetch Users',
+      types: ['my_user'],
+      executionHandler: noop,
+    },
+  ],
+  validateInvocation: noop,
+  getStepStartStates: () => ({
+    'fetch-accounts': {
+      disabled: false,
+    },
+    'fetch-users': {
+      disabled: false,
+    },
+  }),
+};

--- a/src/framework/__tests__/config.test.ts
+++ b/src/framework/__tests__/config.test.ts
@@ -252,7 +252,7 @@ describe('loading config from src/index file', () => {
     });
   });
 
-  test('throws error if configuration is not ', async () => {
+  test('throws error if module does expose configuration as "invocationConfig" export', async () => {
     loadProjectStructure('indexFileEntrypointFailure');
 
     await expect(loadConfig()).rejects.toThrow(

--- a/template/src/index.ts
+++ b/template/src/index.ts
@@ -1,0 +1,11 @@
+import { IntegrationInvocationConfig } from '@jupiterone/integration-sdk';
+
+import instanceConfigFields from './instanceConfigFields';
+import validateInvocation from './validateInvocation';
+import fetchAccounts from './steps';
+
+export const invocationConfig: IntegrationInvocationConfig = {
+  instanceConfigFields,
+  validateInvocation,
+  integrationSteps: [fetchAccounts],
+};

--- a/template/src/instanceConfigFields.json
+++ b/template/src/instanceConfigFields.json
@@ -1,9 +1,0 @@
-{
-  "clientId": {
-    "type": "string"
-  },
-  "clientSecret": {
-    "type": "string",
-    "mask": true
-  }
-}

--- a/template/src/instanceConfigFields.ts
+++ b/template/src/instanceConfigFields.ts
@@ -1,0 +1,13 @@
+import { IntegrationInstanceConfigFieldMap } from '@jupiterone/integration-sdk';
+
+const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
+  clientId: {
+    type: 'string',
+  },
+  clientSecret: {
+    type: 'string',
+    mask: true,
+  },
+};
+
+export default instanceConfigFields;


### PR DESCRIPTION
Addresses #124. I'm only deprecating the convention style loading for now and not removing things entirely so that others that are actively working on integrations can still pick up some changes (data model upgrades or small additions) without breaking their integration.

I want to add better validation and potentially introduce some type-gen or other tool to help keep static types and runtime validation code in sync. That may become a larger change and what's here is enough to allow us to start making deploys easier with the managed runtime. When we do the 1.0.0 release, we'll drop the convention loading entirely. 