### PR TITLE
v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## 1.0.0
+
 ### Added
 
 - Support loading invocation configuration from `src/index`.
@@ -15,6 +17,11 @@ and this project adheres to
 ### Deprecated
 
 - Deprecated convention style loading.
+
+### Changed
+
+- Bumped to `1.0.0` so that dependent projects can get regular semver rules and
+  cleaner updates.
 
 ## 0.18.0 2020-05-01
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk",
-  "version": "0.18.0",
+  "version": "1.0.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "src/framework/index.js",
   "types": "src/framework/index.d.ts",

--- a/src/framework/config.ts
+++ b/src/framework/config.ts
@@ -38,7 +38,7 @@ export async function loadConfig(
 
   if (!config) {
     log.warn(
-      'WARNING: Automatically loading configurations from a directory structure is deprecated and will be removed in the 1.0.0 release.\n' +
+      'WARNING: Automatically loading configurations from a directory structure is deprecated and will be removed in a future release when the SDK is broken up into multiple packages.\n' +
         'Please migrate your integration to export the integration configuration at "src/index".\n' +
         'For more information, see https://github.com/JupiterOne/integration-sdk/issues/125',
     );


### PR DESCRIPTION
We ran into some unexpected pain points with how sub `1.0.0` packages were getting treated when performing upgrades so we're going to bump to `1.0.0` so that we can get better versioning for this project going forward as incremental changes are introduced. 

Big changes are coming and integrations will start using the `@jupiterone/integration-sdk-(core|cli|runtime)` family of packages pretty soon. 