### PR TITLE
Add additional data from synchronization jobs to logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added additional logging to `finalizeSynchronization` and
+  `executeIntegrationInstance`.
+
+### Changed
+
+- `registerSynchronizationJobContext` now returns a child logger.
+- `initiateSynchronization` registers the synchronization job with the `logger`
+  and returns a child logger with more information.
+
 ## 1.0.0
 
 ### Added

--- a/src/__tests__/generateSynchronizationJob.ts
+++ b/src/__tests__/generateSynchronizationJob.ts
@@ -1,0 +1,22 @@
+import {
+  SynchronizationJobStatus,
+  SynchronizationJob,
+} from '../framework/synchronization';
+
+export function generateSynchronizationJob(): SynchronizationJob {
+  return {
+    id: 'test',
+    integrationJobId: 'test-job-id',
+    integrationInstanceId: 'test-instance-id',
+    status: SynchronizationJobStatus.AWAITING_UPLOADS,
+    startTimestamp: Date.now(),
+    numEntitiesUploaded: 0,
+    numEntitiesCreated: 0,
+    numEntitiesUpdated: 0,
+    numEntitiesDeleted: 0,
+    numRelationshipsUploaded: 0,
+    numRelationshipsCreated: 0,
+    numRelationshipsUpdated: 0,
+    numRelationshipsDeleted: 0,
+  };
+}

--- a/src/cli/__tests__/cli-run-failure.test.ts
+++ b/src/cli/__tests__/cli-run-failure.test.ts
@@ -87,6 +87,9 @@ test('does not log errors that have been previously logged', async () => {
   const errorSpy = jest.spyOn(logger, 'error');
 
   jest.spyOn(logger, 'child').mockReturnValue(logger);
+  jest
+    .spyOn(logger, 'registerSynchronizationJobContext')
+    .mockReturnValue(logger);
 
   mocked(mockCreateIntegrationLogger).mockReturnValue(logger);
 

--- a/src/cli/__tests__/util/synchronization.ts
+++ b/src/cli/__tests__/util/synchronization.ts
@@ -4,6 +4,8 @@ import {
   SynchronizationJobStatus,
 } from '../../../framework/synchronization';
 
+export { generateSynchronizationJob } from '../../../__tests__/generateSynchronizationJob';
+
 interface SetupOptions {
   baseUrl: string;
   polly: Polly;
@@ -68,20 +70,4 @@ function allowCrossOrigin(req, res) {
       'access-control-request-headers',
     ),
   });
-}
-
-export function generateSynchronizationJob(): SynchronizationJob {
-  return {
-    id: 'test',
-    status: SynchronizationJobStatus.AWAITING_UPLOADS,
-    startTimestamp: Date.now(),
-    numEntitiesUploaded: 0,
-    numEntitiesCreated: 0,
-    numEntitiesUpdated: 0,
-    numEntitiesDeleted: 0,
-    numRelationshipsUploaded: 0,
-    numRelationshipsCreated: 0,
-    numRelationshipsUpdated: 0,
-    numRelationshipsDeleted: 0,
-  };
 }

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -37,7 +37,7 @@ export function run() {
 
       const { integrationInstanceId } = options;
 
-      const logger = createIntegrationLogger({
+      let logger = createIntegrationLogger({
         name: 'local',
         pretty: true,
       });
@@ -50,7 +50,7 @@ export function run() {
         integrationInstanceId,
       });
 
-      logger.registerSynchronizationJobContext(synchronizationContext);
+      logger = synchronizationContext.logger;
 
       try {
         const executionResults = await executeIntegrationInstance(

--- a/src/framework/execution/executeIntegration.ts
+++ b/src/framework/execution/executeIntegration.ts
@@ -112,5 +112,10 @@ async function executeIntegration(
     data: summary,
   });
 
+  context.logger.info(
+    { collectionResult: summary },
+    'Integration data collection has completed.',
+  );
+
   return summary;
 }

--- a/src/framework/execution/types/logger.ts
+++ b/src/framework/execution/types/logger.ts
@@ -29,10 +29,15 @@ interface BaseLogger {
   child: ChildLogFunction;
 }
 
+export type LoggerSynchronizationJobContext = Pick<
+  SynchronizationJobContext,
+  'apiClient' | 'job'
+>;
+
 export interface IntegrationLogger extends BaseLogger {
   registerSynchronizationJobContext: (
-    context: SynchronizationJobContext,
-  ) => void;
+    context: LoggerSynchronizationJobContext,
+  ) => IntegrationLogger;
 
   isHandledError: IsHandledErrorFunction;
 

--- a/src/framework/synchronization/index.ts
+++ b/src/framework/synchronization/index.ts
@@ -90,9 +90,9 @@ export async function initiateSynchronization({
   return {
     apiClient,
     job,
-    logger: logger.child({
-      integrationInstanceId,
-      synchronizationJobId: job.id,
+    logger: logger.registerSynchronizationJobContext({
+      apiClient,
+      job,
     }),
   };
 }
@@ -111,7 +111,7 @@ export async function finalizeSynchronization({
   logger,
   partialDatasets,
 }: FinalizeSynchronizationInput): Promise<SynchronizationJob> {
-  logger.info('Finalizing synchronization');
+  logger.info('Finalizing synchronization...');
 
   let finalizedJob: SynchronizationJob;
 
@@ -129,6 +129,11 @@ export async function finalizeSynchronization({
       'Error occurred while finalizing synchronization job.',
     );
   }
+
+  logger.info(
+    { synchronizationJob: finalizedJob },
+    'Synchronization finalization result.',
+  );
 
   return finalizedJob;
 }

--- a/src/framework/synchronization/types.ts
+++ b/src/framework/synchronization/types.ts
@@ -11,6 +11,8 @@ export enum SynchronizationJobStatus {
 
 export interface SynchronizationJob {
   id: string;
+  integrationJobId: string;
+  integrationInstanceId: string;
   status: SynchronizationJobStatus;
   startTimestamp: number;
   numEntitiesUploaded: number;

--- a/src/testing/__tests__/context.test.ts
+++ b/src/testing/__tests__/context.test.ts
@@ -1,6 +1,11 @@
 import noop from 'lodash/noop';
 
-import { Entity, Relationship, IntegrationStep } from '../../framework';
+import {
+  Entity,
+  Relationship,
+  IntegrationStep,
+  SynchronizationJobContext,
+} from '../../framework';
 import { LOCAL_INTEGRATION_INSTANCE } from '../../framework/execution/instance';
 
 import {
@@ -36,11 +41,21 @@ import { v4 as uuid } from 'uuid';
         const { logger } = createContext();
 
         Object.keys(logger).forEach((key) => {
-          if (key !== 'child' && key !== 'flush' && key !== 'isHandledError') {
+          if (
+            key !== 'child' &&
+            key !== 'registerSynchronizationJobContext' &&
+            key !== 'flush' &&
+            key !== 'isHandledError'
+          ) {
             expect(logger[key]).toEqual(noop);
           }
         });
 
+        expect(
+          logger.registerSynchronizationJobContext(
+            {} as SynchronizationJobContext,
+          ),
+        ).toEqual(logger);
         expect(logger.child({})).toEqual(logger);
         expect(logger.flush).toEqual(noopAsync);
       });

--- a/src/testing/logger.ts
+++ b/src/testing/logger.ts
@@ -10,7 +10,9 @@ export function createMockIntegrationLogger(): IntegrationLogger {
     warn: noop,
     error: noop,
     fatal: noop,
-    registerSynchronizationJobContext: noop,
+    registerSynchronizationJobContext() {
+      return this;
+    },
     isHandledError: () => false,
     stepStart: noop,
     stepSuccess: noop,


### PR DESCRIPTION
This adds logging to end of the synchronization finalize and data collection functions so that the runtime doesn't need to add the information itself.

Tweaks `logger.registerSynchronizationJobContext` to return a child logger
with added information from the synchronizationJob.
Tweaks `initiateSynchronization` to perform the `logger.registerSynchronizationJobContext`
instead of just creating a child logger.