### PR TITLE
Add some types of execution errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Documentation on `IntegrationError` to clarify that it is not meant to be used
+  directly outside the SDK.
+- New errors that integrations should throw to communicate provider API errors
+  during `validateInvocation` or any step. These will terminate the step, but
+  provide more details to users to help them resolve some kinds of provider API
+  errors.
+
+### Changed
+
+- Removed an unused error `IntegrationConfigValidationError`.
+- Renamed `IntegrationLocalConfigFieldTypeMismatch` to
+  `IntegrationLocalConfigFieldTypeMismatchError`, to match other error names.
+
 ## 1.1.0 - 2020-05-13
 
 ### Added

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,27 +1,80 @@
 export const UNEXPECTED_ERROR_CODE = 'UNEXPECTED_ERROR';
 export const UNEXPECTED_ERROR_REASON =
-  'Unexpected error occurred executing integration! Please contact us in Slack or at https://support.jupiterone.io if the problem continues to occur';
+  'Unexpected error occurred executing integration! Please contact us in Slack or at https://support.jupiterone.io if the problem continues to occur.';
 
 export interface IntegrationErrorOptions {
   message: string;
+
+  /**
+   * A code associated with the error. This should take the form
+   * `SOMETHING_LIKE_THE_CLASS_ERROR`, ending with `_ERROR` an having a name
+   * similar to the class of the error type.
+   */
   code: string;
+
+  /**
+   * An optional flag used to mark the error as fatal. A fatal error will stop
+   * execution of the entire integration.
+   */
   fatal?: boolean;
+
+  /**
+   * An optional reference to the error that caused this error. The cause tree
+   * will be included in logging of the error to assist problem resolution.
+   */
   cause?: Error;
 }
 
+/**
+ * The base type of errors generated during integration execution. Integrations
+ * should not throw this error type directly; use one of the types documented
+ * below.
+ *
+ * All errors occurring during execution of an integration should ultimately end
+ * up as an `IntegrationError`, or a subclass thereof, each expressing a `code`
+ * reflecting the class of the error. In cases when an unhandled `Error` occurs,
+ * which has no `code`, then `"UNEXPECTED_ERROR"` will be used in logging the
+ * error.
+ *
+ * Integrations generally need to throw errors in only a few cases:
+ *
+ * 1. `IntegrationProviderAuthenticationError` - during `validateInvocation`,
+ *    when an attempt to authenticate with the provider has failed.
+ * 1. `IntegrationValidationError` - during `validateInvocation`, when the
+ *    configuration is considered invalid in some way.
+ * 1. `IntegrationProviderAuthorizationError` - during requests to the provider
+ *    API and a `403 Forbidden` or similar response is provided.
+ * 1. `IntegrationProviderAPIError` - during requests to the provider API and an
+ *    unexpected response is provided.
+ * 1. `Error` - any unexpected error should not be caught in the integration;
+ *    the step execution system will catch and report it.
+ *
+ * The integration may catch errors, but they should not be considered terminal
+ * when it does, and the `catch` block should call `logger.warn({err: error },
+ * "Message for production analysis")`. For example:
+ *
+ * ```ts
+ * try {
+ *   // something that could go wrong, but it is handled by the integration
+ * } catch (error) {
+ *   // log it for production analysis, but carry on because we know what we're doing
+ *   logger.warn({ err: error }, "Nothing we can't handle, but someone may come asking");
+ * }
+ * ```
+ */
 export class IntegrationError extends Error {
   /**
-   * Optional cause associated with error.
+   * Optional cause associated with the error.
    */
   readonly _cause?: Error;
 
   /**
-   * An optional code associated with error.
+   * Code associated with the error.
    */
   readonly code: string;
 
   /**
-   * An optional flag used to mark the error as fatal.
+   * Flag used to mark the error as fatal.
    */
   readonly fatal: boolean | undefined;
 

--- a/src/framework/execution/__tests__/dependencyGraph.test.ts
+++ b/src/framework/execution/__tests__/dependencyGraph.test.ts
@@ -1,32 +1,27 @@
-import { v4 as uuid } from 'uuid';
-import times from 'lodash/times';
-import waitForExpect from 'wait-for-expect';
 import { promises as fs } from 'fs';
+import times from 'lodash/times';
 import { vol } from 'memfs';
+import { v4 as uuid } from 'uuid';
+import waitForExpect from 'wait-for-expect';
 
-import { createIntegrationLogger } from '../logger';
-
+import { IntegrationError } from '../../../../src/errors';
+import { Entity, Relationship } from '../../types';
 import {
   buildStepDependencyGraph,
   executeStepDependencyGraph,
 } from '../dependencyGraph';
-
-import { getDefaultStepStartStates } from '../step';
-
 import { LOCAL_INTEGRATION_INSTANCE } from '../instance';
-
+import { createIntegrationLogger } from '../logger';
+import { getDefaultStepStartStates } from '../step';
 import {
-  JobState,
-  IntegrationStep,
-  IntegrationInstance,
-  IntegrationStepResultStatus,
   IntegrationExecutionContext,
-  IntegrationStepExecutionContext,
+  IntegrationInstance,
   IntegrationLogger,
+  IntegrationStep,
+  IntegrationStepExecutionContext,
+  IntegrationStepResultStatus,
+  JobState,
 } from '../types';
-
-import { Entity, Relationship } from '../../types';
-import { IntegrationConfigValidationError } from '../error';
 
 jest.mock('fs');
 
@@ -524,7 +519,10 @@ describe('executeStepDependencyGraph', () => {
   });
 
   test('logs error after step fails', async () => {
-    const error = new IntegrationConfigValidationError('oopsie');
+    const error = new IntegrationError({
+      code: 'ABC-123',
+      message: 'oopsie',
+    });
     let errorLogSpy;
 
     /**
@@ -560,7 +558,7 @@ describe('executeStepDependencyGraph', () => {
       { step: 'a', err: error, errorId: expect.any(String) },
       expect.stringMatching(
         new RegExp(
-          `Step "a" failed to complete due to error. \\(errorCode=${error.code}, errorId=(.*)\\)$`,
+          `Step "a" failed to complete due to error. \\(errorCode=ABC-123, errorId=(.*)\\)$`,
         ),
       ),
     );

--- a/src/framework/execution/config.ts
+++ b/src/framework/execution/config.ts
@@ -2,14 +2,13 @@ import dotenv from 'dotenv';
 import snakeCase from 'lodash/snakeCase';
 
 import {
+  IntegrationLocalConfigFieldMissingError,
+  IntegrationLocalConfigFieldTypeMismatchError,
+} from './error';
+import {
   IntegrationInstanceConfigField,
   IntegrationInstanceConfigFieldMap,
 } from './types';
-
-import {
-  IntegrationLocalConfigFieldMissingError,
-  IntegrationLocalConfigFieldTypeMismatch,
-} from './error';
 
 const dotenvExpand = require('dotenv-expand');
 
@@ -60,7 +59,9 @@ function convertEnvironmentVariableValueForField(
       } else if (rawString === 'false') {
         convertedValue = false;
       } else {
-        throw typeMismatchError(field, environmentVariableValue);
+        throw new IntegrationLocalConfigFieldTypeMismatchError(
+          `Expected boolean value for field "${field}" but received "${environmentVariableValue}".`,
+        );
       }
       break;
     }
@@ -77,11 +78,5 @@ function configFieldMissingError(
 ) {
   throw new IntegrationLocalConfigFieldMissingError(
     `Expected environment variable "${environmentVariableName}" for config field "${field}" to be set.`,
-  );
-}
-
-function typeMismatchError(field: string, value: string) {
-  throw new IntegrationLocalConfigFieldTypeMismatch(
-    `Expected boolean value for field "${field}" but received "${value}".`,
   );
 }

--- a/src/framework/execution/error.ts
+++ b/src/framework/execution/error.ts
@@ -1,4 +1,4 @@
-import { IntegrationError } from '../../errors';
+import { IntegrationError, IntegrationErrorOptions } from '../../errors';
 
 export class IntegrationLocalConfigFieldMissingError extends IntegrationError {
   constructor(message: string) {
@@ -9,7 +9,7 @@ export class IntegrationLocalConfigFieldMissingError extends IntegrationError {
   }
 }
 
-export class IntegrationLocalConfigFieldTypeMismatch extends IntegrationError {
+export class IntegrationLocalConfigFieldTypeMismatchError extends IntegrationError {
   constructor(message: string) {
     super({
       code: 'LOCAL_CONFIG_FIELD_TYPE_MISMATCH',
@@ -21,15 +21,6 @@ export class IntegrationConfigLoadError extends IntegrationError {
   constructor(message: string) {
     super({
       code: 'CONFIG_LOAD_ERROR',
-      message,
-    });
-  }
-}
-
-export class IntegrationConfigValidationError extends IntegrationError {
-  constructor(message: string) {
-    super({
-      code: 'CONFIG_FIELD_TYPE_MISMATCH',
       message,
     });
   }
@@ -63,11 +54,128 @@ export class IntegrationDuplicateKeyError extends IntegrationError {
   }
 }
 
+/**
+ * An error that may be thrown by an integration during `validateInvocation`,
+ * used to communicate something the user should see that can help them fix a
+ * configuration problem.
+ */
 export class IntegrationValidationError extends IntegrationError {
   constructor(message: string) {
     super({
       code: 'CONFIG_VALIDATION_ERROR',
       message,
+    });
+  }
+}
+
+/**
+ * An error that may be thrown by an integration during `validateInvocation`,
+ * used to communicate a provider API authentication error the user should see
+ * that can help them fix a configuration problem. This is a fatal error because
+ * an integration cannot reach the provider.
+ */
+export class IntegrationProviderAuthenticationError extends IntegrationError {
+  constructor(
+    options: IntegrationErrorOptions & {
+      /**
+       * The endpoint that provided the response indicating the authentication
+       * parameters are invalid.
+       */
+      endpoint: string;
+
+      /**
+       * The response status code, i.e. `401`, or in the case of GraphQL, whatever
+       * error code provided by the response body.
+       */
+      status: string | number;
+
+      /**
+       * The response status text, i.e. `"Unauthorized"`.
+       */
+      statusText: string;
+    },
+  ) {
+    super({
+      ...options,
+      code: 'PROVIDER_AUTHENTICATION_ERROR',
+      fatal: true,
+      message: `Provider authentication failed at ${options.endpoint}: ${options.status} ${options.statusText}`,
+    });
+  }
+}
+
+/**
+ * An error that may be thrown by an integration during any step that interacts
+ * with provider APIs, used to communicate an authenticated provider API client
+ * resource access authorization error the user should see that can help them
+ * fix a configuration problem.
+ */
+export class IntegrationProviderAuthorizationError extends IntegrationError {
+  constructor(
+    options: IntegrationErrorOptions & {
+      /**
+       * The endpoint that provided the response indicating the authenticated
+       * client is not authorized to access a resource.
+       */
+      endpoint: string;
+
+      /**
+       * The response status code, i.e. `403`, or in the case of GraphQL, whatever
+       * error code provided by the response body.
+       */
+      status: string | number;
+
+      /**
+       * The response status text, i.e. `"Forbidden"`.
+       */
+      statusText: string;
+
+      /**
+       * The `_type` of entity/relationship data that could not be obtained due to
+       * the authorization error.
+       */
+      resourceType?: string[];
+    },
+  ) {
+    super({
+      ...options,
+      code: 'PROVIDER_AUTHORIZATION_ERROR',
+      fatal: false,
+      message: `Provider authorization failed at ${options.endpoint}: ${options.status} ${options.statusText}`,
+    });
+  }
+}
+
+/**
+ * An error that may be thrown by an integration during any step that interacts
+ * with provider APIs, used to communicate an unexpected provider API error the
+ * user should see that may help them obtain support from the provider.
+ */
+export class IntegrationProviderAPIError extends IntegrationError {
+  constructor(
+    options: IntegrationErrorOptions & {
+      /**
+       * The endpoint that provided the unexpected error response.
+       */
+      endpoint: string;
+
+      /**
+       * The response status code, i.e. `500`, or in the case of GraphQL, whatever
+       * error code provided by the response body.
+       */
+      status: string | number;
+
+      /**
+       * The response status text, i.e. `"Internal Server Error"`.
+       */
+      statusText: string;
+    },
+  ) {
+    super({
+      ...options,
+      code: 'PROVIDER_API_ERROR',
+      fatal: false,
+      message: `Provider API failed at ${options.endpoint}: ${options.status} ${options.statusText}`,
     });
   }
 }


### PR DESCRIPTION
Advances #156. I think we can start with these, but we'll also need something like @charlieduong94 mentioned, `logger.authError`, both for the integration-sdk to use when that type of error is thrown from a step, as well as by the step itself when it doesn't want to terminate, only report that and move on to some other work.