### PR TITLE
Make IntegrationInstance.config a generic type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,41 @@ and this project adheres to
 
 ### Added
 
+- `Entity` now includes a property `id?: string` to represent the
+  [`id` property supported by the data model](https://github.com/JupiterOne/data-model/blob/f07f085b39041e639f5dacd9b6140c6c3db0b5ad/src/schemas/Entity.json#L10).
+  This allows for easy reference to `Entity.id` in later steps that iterate
+  already-loaded entities and don't want to assume that the `_key` _is_ the
+  provider's identifier (often the `_key` needs additional data to make it
+  unique). Note that we plan to soon provide TS types for all the data model
+  types.
+
+### Changed
+
+- BREAKING! Historically, the `IntegrationInstance.config` was typed as `any`.
+  This provided no type safety. Now, integrations must declare an interface
+  represeting the structure of their `IntegrationInstance.config` and provide
+  this as a type parameter in code where there is a need to access the `config`
+  properties. The type parameter is not required (defaults to type `object`),
+  but there will be no access to properties (without an evil type cast to
+  `any`).
+
+  The following types now support a generic parameter for the `instance.config`
+  they or their properties reference:
+
+  - `IntegrationInstance`,
+  - `IntegrationInvocationConfig`,
+  - `IntegrationExecutionContext`,
+  - `IntegrationStepExecutionContext`
+  - `IntegrationStep`
+  - `GetStepStartStatesFunction`
+  - `StepExecutionHandlerFunction`
+  - `InvocationValidationFunction`
+  - `createMockExecutionContext`
+
+## 1.1.1 - 2020-05-14
+
+### Added
+
 - Documentation on `IntegrationError` to clarify that it is not meant to be used
   directly outside the SDK.
 - New errors that integrations should throw to communicate provider API errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 2.0.0 - 2020-05-18
 
 ### Added
 
 - `JobState.setData(key, data)` and `JobState.getData(key)` allow steps to
   communicate arbitrary data to dependent steps.
-
-## 1.1.2 - 2020-05-15
-
-- Slight modifications to support mapped relationships
-
-## 1.1.1 - 2020-05-14
-
-### Added
 
 - `Entity` now includes a property `id?: string` to represent the
   [`id` property supported by the data model](https://github.com/JupiterOne/data-model/blob/f07f085b39041e639f5dacd9b6140c6c3db0b5ad/src/schemas/Entity.json#L10).
@@ -51,6 +43,26 @@ and this project adheres to
   - `StepExecutionHandlerFunction`
   - `InvocationValidationFunction`
   - `createMockExecutionContext`
+
+## 1.1.4 - 2020-05-18
+
+### Fixed
+
+- `addRelationship` added to entities collection instead of relationships.
+
+## 1.1.3 - 2020-05-16
+
+### Changed
+
+- Upgraded to `@jupiterone/data-model@0.4.1`
+
+## 1.1.2 - 2020-05-15
+
+### Fixed
+
+- `createIntegrationRelationship` did not allow for providing the relationship
+  mapping `_key` property. This is necessary in the synchronizer to allow it to
+  track the mapping rule.
 
 ## 1.1.1 - 2020-05-14
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk",
-  "version": "1.1.4",
+  "version": "2.0.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "src/framework/index.js",
   "types": "src/framework/index.d.ts",

--- a/src/__tests__/__fixtures__/typeScriptIntegrationProject/src/steps/fetchAccounts.ts
+++ b/src/__tests__/__fixtures__/typeScriptIntegrationProject/src/steps/fetchAccounts.ts
@@ -7,7 +7,9 @@ export default {
   id: 'fetch-accounts',
   name: 'Fetch Accounts',
   types: ['my_account'],
-  executionHandler: async ({ jobState }: IntegrationStepExecutionContext) => {
+  executionHandler: async ({
+    jobState,
+  }: IntegrationStepExecutionContext<{}>) => {
     await jobState.addEntities([
       createIntegrationEntity({
         entityData: {

--- a/src/__tests__/__fixtures__/typeScriptIntegrationProject/src/steps/fetchUsers.ts
+++ b/src/__tests__/__fixtures__/typeScriptIntegrationProject/src/steps/fetchUsers.ts
@@ -8,7 +8,9 @@ export default {
   id: 'fetch-users',
   name: 'Fetch Users',
   types: ['my_user'],
-  executionHandler: async ({ jobState }: IntegrationStepExecutionContext) => {
+  executionHandler: async ({
+    jobState,
+  }: IntegrationStepExecutionContext<{}>) => {
     await jobState.addEntities([
       createIntegrationEntity({
         entityData: {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -86,9 +86,7 @@ export class IntegrationError extends Error {
   }
 
   /**
-   * For compatibility with bunyan err serializer.
-   *
-   * See https://github.com/trentm/node-bunyan/blob/master/lib/bunyan.js#L1125
+   * For compatibility with [bunyan err serializer](https://github.com/trentm/node-bunyan/blob/master/lib/bunyan.js#L1125).
    */
   cause() {
     return this._cause;

--- a/src/framework/config.ts
+++ b/src/framework/config.ts
@@ -1,18 +1,16 @@
-import path from 'path';
 import { promises as fs } from 'fs';
-
 import globby from 'globby';
+import path from 'path';
 
 import { IntegrationError } from '../errors';
-import * as log from '../log';
-
 import {
-  IntegrationInvocationConfig,
-  IntegrationInstanceConfigFieldMap,
-  InvocationValidationFunction,
   GetStepStartStatesFunction,
+  IntegrationInstanceConfigFieldMap,
+  IntegrationInvocationConfig,
   IntegrationStep,
+  InvocationValidationFunction,
 } from '../framework/execution';
+import * as log from '../log';
 
 export class IntegrationInvocationConfigNotFoundError extends IntegrationError {
   constructor(message: string) {
@@ -103,8 +101,8 @@ export function loadInstanceConfigFields(
  */
 export function loadValidateInvocationFunction(
   projectSourceDirectory: string = path.join(process.cwd(), 'src'),
-) {
-  return loadModuleContent<InvocationValidationFunction>(
+): InvocationValidationFunction | undefined {
+  return loadModuleContent(
     path.resolve(projectSourceDirectory, 'validateInvocation'),
   );
 }

--- a/src/framework/data/createIntegrationEntity.ts
+++ b/src/framework/data/createIntegrationEntity.ts
@@ -84,7 +84,9 @@ export type IntegrationEntityData = {
 
   /**
    * The names of properties that will be assigned directly to the entity from
-   * tags with matching names. See `assignTags`.
+   * tags with matching names.
+   *
+   * @see assignTags
    */
   tagProperties?: string[];
 };

--- a/src/framework/execution/__tests__/dependencyGraph.test.ts
+++ b/src/framework/execution/__tests__/dependencyGraph.test.ts
@@ -27,7 +27,7 @@ jest.mock('fs');
 
 afterEach(() => vol.reset());
 
-const executionContext: IntegrationExecutionContext = {
+const executionContext: IntegrationExecutionContext<{}> = {
   logger: createIntegrationLogger({
     name: 'step logger',
     invocationConfig: {
@@ -112,11 +112,11 @@ describe('buildStepDependencyGraph', () => {
 describe('executeStepDependencyGraph', () => {
   test('executionHandler should have access to "jobState", "logger", and "instance" objects', async () => {
     let jobState: JobState;
-    let instance: IntegrationInstance;
+    let instance: IntegrationInstance<{}>;
     let logger: IntegrationLogger;
 
     const executionHandlerSpy = jest.fn(
-      (context: IntegrationStepExecutionContext) => {
+      (context: IntegrationStepExecutionContext<{}>) => {
         jobState = context.jobState;
         instance = context.instance;
         logger = context.logger;

--- a/src/framework/execution/config.ts
+++ b/src/framework/execution/config.ts
@@ -6,6 +6,7 @@ import {
   IntegrationLocalConfigFieldTypeMismatchError,
 } from './error';
 import {
+  IntegrationInstanceConfig,
   IntegrationInstanceConfigField,
   IntegrationInstanceConfigFieldMap,
 } from './types';
@@ -15,9 +16,9 @@ const dotenvExpand = require('dotenv-expand');
 /**
  * Reads integration configuration from environment variables
  */
-export function loadConfigFromEnvironmentVariables(
-  configMap: IntegrationInstanceConfigFieldMap,
-): Record<string, string | boolean> {
+export function loadConfigFromEnvironmentVariables<
+  TConfig extends IntegrationInstanceConfig
+>(configMap: IntegrationInstanceConfigFieldMap): TConfig {
   // pull in environment variables from .env file if available
   dotenvExpand(dotenv.config());
 
@@ -41,7 +42,7 @@ export function loadConfigFromEnvironmentVariables(
     .reduce((acc: Record<string, string | boolean>, [field, value]) => {
       acc[field] = value;
       return acc;
-    }, {});
+    }, {}) as TConfig;
 }
 
 function convertEnvironmentVariableValueForField(

--- a/src/framework/execution/dependencyGraph.ts
+++ b/src/framework/execution/dependencyGraph.ts
@@ -8,12 +8,12 @@ import {
   MemoryDataStore,
 } from './jobState';
 import {
+  IntegrationExecutionContext,
   IntegrationStep,
+  IntegrationStepExecutionContext,
   IntegrationStepResult,
   IntegrationStepResultStatus,
   IntegrationStepStartStates,
-  IntegrationExecutionContext,
-  IntegrationStepExecutionContext,
 } from './types';
 
 /**

--- a/src/framework/execution/instance.ts
+++ b/src/framework/execution/instance.ts
@@ -1,5 +1,5 @@
-import { IntegrationInstance, IntegrationInvocationConfig } from './types';
 import { loadConfigFromEnvironmentVariables } from './config';
+import { IntegrationInstance, IntegrationInvocationConfig } from './types';
 
 export const LOCAL_INTEGRATION_INSTANCE: IntegrationInstance = {
   id: 'local-integration-instance',
@@ -7,7 +7,7 @@ export const LOCAL_INTEGRATION_INSTANCE: IntegrationInstance = {
   name: 'Local Integration',
   integrationDefinitionId: 'local-integration-definition',
   description: 'A generated integration instance for local execution',
-  config: undefined,
+  config: {},
 } as const;
 
 export function createIntegrationInstanceForLocalExecution(
@@ -21,7 +21,7 @@ export function createIntegrationInstanceForLocalExecution(
     ...LOCAL_INTEGRATION_INSTANCE,
     config: config.instanceConfigFields
       ? loadConfigFromEnvironmentVariables(config.instanceConfigFields)
-      : undefined,
+      : {},
     accountId,
   };
 }

--- a/src/framework/execution/logger.ts
+++ b/src/framework/execution/logger.ts
@@ -1,22 +1,21 @@
-import { v4 as uuid } from 'uuid';
 import Logger from 'bunyan';
 import PromiseQueue from 'p-queue';
+import { v4 as uuid } from 'uuid';
 
-import {
-  IntegrationLogger,
-  IntegrationStep,
-  IntegrationInstance,
-  IntegrationInvocationConfig,
-  IntegrationInstanceConfigFieldMap,
-  LoggerSynchronizationJobContext,
-} from './types';
-
-import { SynchronizationJob } from '../synchronization';
 import {
   IntegrationError,
   UNEXPECTED_ERROR_CODE,
   UNEXPECTED_ERROR_REASON,
 } from '../../errors';
+import { SynchronizationJob } from '../synchronization';
+import {
+  IntegrationInstance,
+  IntegrationInstanceConfigFieldMap,
+  IntegrationInvocationConfig,
+  IntegrationLogger,
+  IntegrationStep,
+  LoggerSynchronizationJobContext,
+} from './types';
 
 // eslint-disable-next-line
 const bunyanFormat = require('bunyan-format');

--- a/src/framework/execution/step.ts
+++ b/src/framework/execution/step.ts
@@ -4,10 +4,9 @@ import {
   buildStepDependencyGraph,
   executeStepDependencyGraph,
 } from './dependencyGraph';
-
 import {
-  IntegrationStep,
   IntegrationExecutionContext,
+  IntegrationStep,
   IntegrationStepResult,
   IntegrationStepResultStatus,
   IntegrationStepStartStates,

--- a/src/framework/execution/types/config.ts
+++ b/src/framework/execution/types/config.ts
@@ -1,12 +1,14 @@
-import { IntegrationStep, GetStepStartStatesFunction } from './step';
-
+import { IntegrationInstanceConfig } from './instance';
+import { GetStepStartStatesFunction, IntegrationStep } from './step';
 import { InvocationValidationFunction } from './validation';
 
-export interface IntegrationInvocationConfig {
+export interface IntegrationInvocationConfig<
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+> {
   instanceConfigFields?: IntegrationInstanceConfigFieldMap;
-  validateInvocation?: InvocationValidationFunction;
-  getStepStartStates?: GetStepStartStatesFunction;
-  integrationSteps: IntegrationStep[];
+  validateInvocation?: InvocationValidationFunction<TConfig>;
+  getStepStartStates?: GetStepStartStatesFunction<TConfig>;
+  integrationSteps: IntegrationStep<TConfig>[];
 }
 
 export interface IntegrationInstanceConfigField {

--- a/src/framework/execution/types/context.ts
+++ b/src/framework/execution/types/context.ts
@@ -1,14 +1,24 @@
+import { IntegrationInstance, IntegrationInstanceConfig } from './instance';
 import { JobState } from './jobState';
-
-import { IntegrationInstance } from './instance';
 import { IntegrationLogger } from './logger';
 
-export interface IntegrationExecutionContext {
-  instance: IntegrationInstance;
+/**
+ * @param TConfig the integration specific type of the `instance.config`
+ * property
+ */
+export interface IntegrationExecutionContext<
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+> {
+  instance: IntegrationInstance<TConfig>;
   logger: IntegrationLogger;
 }
 
-export interface IntegrationStepExecutionContext
-  extends IntegrationExecutionContext {
+/**
+ * @param TConfig the integration specific type of the `instance.config`
+ * property
+ */
+export interface IntegrationStepExecutionContext<
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+> extends IntegrationExecutionContext<TConfig> {
   jobState: JobState;
 }

--- a/src/framework/execution/types/instance.ts
+++ b/src/framework/execution/types/instance.ts
@@ -1,8 +1,14 @@
+export type IntegrationInstanceConfig = object;
+
 /**
  * A stored user configuration for executing the integration defined by
  * the associated `integrationDefinitionId`.
+ *
+ * @param TConfig the integration specific type of the `config` property
  */
-export interface IntegrationInstance {
+export interface IntegrationInstance<
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+> {
   /**
    * Unique identifier for the activated integration instance.
    */
@@ -38,5 +44,5 @@ export interface IntegrationInstance {
    * configuration upon invocation and provide useful configuration error
    * messages.
    */
-  config: any;
+  config: TConfig;
 }

--- a/src/framework/execution/types/step.ts
+++ b/src/framework/execution/types/step.ts
@@ -2,6 +2,7 @@ import {
   IntegrationExecutionContext,
   IntegrationStepExecutionContext,
 } from './context';
+import { IntegrationInstanceConfig } from './instance';
 
 export interface IntegrationStepStartState {
   /**
@@ -16,9 +17,15 @@ export type IntegrationStepStartStates = Record<
   IntegrationStepStartState
 >;
 
-export type GetStepStartStatesFunction = (
-  context: IntegrationExecutionContext,
+export type GetStepStartStatesFunction<
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+> = (
+  context: IntegrationExecutionContext<TConfig>,
 ) => IntegrationStepStartStates;
+
+export type StepExecutionHandlerFunction<
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+> = (context: IntegrationStepExecutionContext<TConfig>) => Promise<void> | void;
 
 export enum IntegrationStepResultStatus {
   SUCCESS = 'success',
@@ -28,13 +35,13 @@ export enum IntegrationStepResultStatus {
   PENDING_EVALUATION = 'pending_evaluation',
 }
 
-export type IntegrationStep = IntegrationStepMetadata & {
+export type IntegrationStep<
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+> = IntegrationStepMetadata & {
   /**
    * Function that runs to perform the stpe that
    */
-  executionHandler: (
-    context: IntegrationStepExecutionContext,
-  ) => Promise<void> | void;
+  executionHandler: StepExecutionHandlerFunction<TConfig>;
 };
 
 export type IntegrationStepResult = IntegrationStepMetadata & {

--- a/src/framework/execution/types/validation.ts
+++ b/src/framework/execution/types/validation.ts
@@ -1,5 +1,6 @@
 import { IntegrationExecutionContext } from './context';
+import { IntegrationInstanceConfig } from './instance';
 
-export type InvocationValidationFunction = (
-  context: IntegrationExecutionContext,
-) => Promise<void> | void;
+export type InvocationValidationFunction<
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+> = (context: IntegrationExecutionContext<TConfig>) => Promise<void> | void;

--- a/src/framework/types/entity.ts
+++ b/src/framework/types/entity.ts
@@ -9,7 +9,14 @@ interface EntityCoreProperties extends Omit<PersistedObject, '_class'> {
   _class: string | string[];
 }
 
-type EntityAdditionalProperties = Record<string, EntityPropertyValue>;
+type EntityAdditionalProperties = Record<string, EntityPropertyValue> & {
+  /**
+   * The natural identifier of the entity as provided by the data source API.
+   * Many APIs answer resources that each have an `id` property that should be
+   * transferred to this entity property.
+   */
+  id?: string;
+};
 
 type EntityPropertyValue =
   | Array<string | number | boolean>

--- a/src/testing/recording.ts
+++ b/src/testing/recording.ts
@@ -1,8 +1,8 @@
 import { Har } from 'har-format';
 import defaultsDeep from 'lodash/defaultsDeep';
 
-import { Polly, PollyConfig } from '@pollyjs/core';
 import NodeHttpAdapter from '@pollyjs/adapter-node-http';
+import { Polly, PollyConfig } from '@pollyjs/core';
 import FSPersister from '@pollyjs/persister-fs';
 
 Polly.register(NodeHttpAdapter);
@@ -23,14 +23,15 @@ interface SetupRecordingInput {
 const SENSITIVE_HEADER_NAMES = ['authorization'].map((i) => i.toLowerCase());
 
 /**
- * @description Sets up a recording of all http requests and
- * writes the data to disk when it is stopped.
- * This leverages Polly.js to do all the heavy lifting.
- * @param input.mutateRequest - allows mutating the `PollyRequest` object
- * pre flight, this affects how the request is sent out and also how it
- * is stored.  This is currently the only known way to get compressed (gzip, broli, etc.)
- * requests to persist their body to the har file.
- * See: https://github.com/Netflix/pollyjs/blob/master/packages/%40pollyjs/core/src/-private/request.js#L30
+ * Sets up a recording of all http requests and writes the data to disk when it
+ * is stopped. This leverages Polly.js to do all the heavy lifting.
+ *
+ * @param input.mutateRequest allows [mutating the
+ * `PollyRequest`](https://github.com/Netflix/pollyjs/blob/master/packages/%40pollyjs/core/src/-private/request.js#L30)
+ * object pre flight, affecting how the request is sent out and how it is
+ * stored.  This is currently the only known way to get compressed (gzip, broli,
+ * etc.) requests to persist their body to the har file.
+ *
  * @example
  * ```typescript
  * let recording;

--- a/template/src/index.ts
+++ b/template/src/index.ts
@@ -1,10 +1,11 @@
 import { IntegrationInvocationConfig } from '@jupiterone/integration-sdk';
 
 import instanceConfigFields from './instanceConfigFields';
-import validateInvocation from './validateInvocation';
 import fetchAccounts from './steps';
+import { IntegrationConfig } from './types';
+import validateInvocation from './validateInvocation';
 
-export const invocationConfig: IntegrationInvocationConfig = {
+export const invocationConfig: IntegrationInvocationConfig<IntegrationConfig> = {
   instanceConfigFields,
   validateInvocation,
   integrationSteps: [fetchAccounts],

--- a/template/src/steps/fetchAccounts.ts
+++ b/template/src/steps/fetchAccounts.ts
@@ -4,14 +4,16 @@ import {
   createIntegrationEntity,
 } from '@jupiterone/integration-sdk';
 
-const step: IntegrationStep = {
+import { IntegrationConfig } from '../types';
+
+const step: IntegrationStep<IntegrationConfig> = {
   id: 'fetch-accounts',
   name: 'Fetch accounts',
   types: ['my_integration_account'],
   async executionHandler({
     logger,
     jobState,
-  }: IntegrationStepExecutionContext) {
+  }: IntegrationStepExecutionContext<IntegrationConfig>) {
     await jobState.addEntities([
       createIntegrationEntity({
         entityData: {

--- a/template/src/types.ts
+++ b/template/src/types.ts
@@ -1,0 +1,17 @@
+import { IntegrationInstanceConfig } from '@jupiterone/integration-sdk';
+
+/**
+ * Properties provided by the `IntegrationInstance.config`. This reflects the
+ * same properties defined by `instanceConfigFields`.
+ */
+export interface IntegrationConfig extends IntegrationInstanceConfig {
+  /**
+   * The provider API client ID used to authenticate requests.
+   */
+  clientId: string;
+
+  /**
+   * The provider API client secret used to authenticate requests.
+   */
+  clientSecret: string;
+}

--- a/template/src/validateInvocation.ts
+++ b/template/src/validateInvocation.ts
@@ -1,7 +1,8 @@
 import { IntegrationExecutionContext } from '@jupiterone/integration-sdk';
+import { IntegrationConfig } from './types';
 
 export default async function validateInvocation(
-  context: IntegrationExecutionContext,
+  context: IntegrationExecutionContext<IntegrationConfig>,
 ) {
   context.logger.info(
     {
@@ -17,7 +18,7 @@ export default async function validateInvocation(
   }
 }
 
-async function isConfigurationValid(config: any) {
+async function isConfigurationValid(config: IntegrationConfig) {
   // add your own validation logic to ensure you
   // can hit the provider's apis.
   return config.clientId && config.clientSecret;


### PR DESCRIPTION
Closes #70. I'm using this in the Azure integration, using `yarn link` (and `autobuild` @philidem !). It's great.