### PR TITLE
Add JobState.set/getData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- `JobState.setData(key, data)` and `JobState.getData(key)` allow steps to
+  communicate arbitrary data to dependent steps.
+
+## 1.1.2 - 2020-05-15
+
 - Slight modifications to support mapped relationships
 
 ## 1.1.1 - 2020-05-14

--- a/src/framework/execution/types/jobState.ts
+++ b/src/framework/execution/types/jobState.ts
@@ -14,6 +14,33 @@ export type GraphObjectIteratee<T> = (obj: T) => void | Promise<void>;
  */
 export interface JobState {
   /**
+   * Store arbitrary data for use in dependent steps.
+   *
+   * Integrations often need a means of storing some information other than
+   * entities and relationships for use across steps. This simple mechanism
+   * makes no asumptions about the content of the data, and a single value can
+   * be stored per key, though the value can be as complex as necessary.
+   *
+   * This mechanism is not meant to replace storage and retrieval of
+   * entities/relationships across steps. That is, this mechanism is for smaller
+   * amounts of transient data.
+   */
+  setData: <T>(key: string, data: T) => Promise<void>;
+
+  /**
+   * Retrieve arbitrary data stored by parent steps.
+   *
+   * Keep in mind that steps are executed in an order that respects the step
+   * dependency graph. A step will only see the data stored in previous steps it
+   * depends on. Other steps outside the dependency ancestry may not have run
+   * and therefore data collected by those other steps should not be expected to
+   * exist.
+   *
+   * @see setData
+   */
+  getData: <T>(key: string) => Promise<T>;
+
+  /**
    * Adds an entity to the job's collection. `addEntities` can be used
    * to add a batch of entities to the collection.
    */

--- a/src/testing/__tests__/jobState.test.ts
+++ b/src/testing/__tests__/jobState.test.ts
@@ -2,6 +2,21 @@ import { Entity, Relationship } from '../../framework';
 
 import { MockJobState, createMockJobState } from '../jobState';
 
+describe('data', () => {
+  test('creates a job state object that can set and get data', async () => {
+    const jobState = createMockJobState();
+    await jobState.setData('my-key', 'whatever');
+    await expect(jobState.getData('my-key')).resolves.toEqual('whatever');
+  });
+
+  test('replaces existing data', async () => {
+    const jobState = createMockJobState();
+    await jobState.setData('my-key', 'whatever');
+    await jobState.setData('my-key', 'ohyeah');
+    await expect(jobState.getData('my-key')).resolves.toEqual('ohyeah');
+  });
+});
+
 describe('entities', () => {
   const inputEntities: Entity[] = [
     {

--- a/src/testing/jobState.ts
+++ b/src/testing/jobState.ts
@@ -1,5 +1,8 @@
 import { Entity, JobState, Relationship } from '../framework';
-import { DuplicateKeyTracker } from '../framework/execution/jobState';
+import {
+  DuplicateKeyTracker,
+  MemoryDataStore,
+} from '../framework/execution/jobState';
 
 export interface CreateMockJobStateOptions {
   entities?: Entity[];
@@ -31,6 +34,7 @@ export function createMockJobState({
   let collectedRelationships: Relationship[] = [];
 
   const duplicateKeyTracker = new DuplicateKeyTracker();
+  const dataStore = new MemoryDataStore();
 
   const addEntities = async (newEntities) => {
     newEntities.forEach((e) => duplicateKeyTracker.registerKey(e._key));
@@ -51,6 +55,14 @@ export function createMockJobState({
 
     get collectedRelationships() {
       return collectedRelationships;
+    },
+
+    setData: async <T>(key: string, data: T): Promise<void> => {
+      dataStore.set(key, data);
+    },
+
+    getData: async <T>(key: string): Promise<T> => {
+      return dataStore.get(key) as T;
     },
 
     addEntity: async (entity: Entity) => {


### PR DESCRIPTION
Advances #131.

I wonder if `JobState` is the right place to put something like this, because it seems that object is focused on interfacing with the `GraphObjectStore`. An alternative would be to have this kind of thing on the `IntegrationStepExecutionContext` itself.

I'd like to have this in the Azure integration to store the singleton `Account` entity in the first step that other steps depend on to build relationships to the account. Compare to using `iterateEntities` to find the single object.

Please provide any feedback you have on how this might be improved/better satisfy #131.