### PR TITLE
Initial changes to refactor integration execution

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -994,7 +994,7 @@ Entity data will be published to
 `https://api.us.jupiterone.io/synchronization/:integrationInstanceId/jobs/:jobId/entities`.
 
 Relationship data will be published to
-`https://api.us.jupiterone.io//synchronization/:integrationInstanceId/jobs/:jobId/relationships`.
+`https://api.us.jupiterone.io/synchronization/:integrationInstanceId/jobs/:jobId/relationships`.
 
 After all of the data under the `.j1-integration/graph` directory has been
 published, the CLI will `POST` to

--- a/src/__tests__/generateSynchronizationJob.ts
+++ b/src/__tests__/generateSynchronizationJob.ts
@@ -1,13 +1,12 @@
 import {
   SynchronizationJobStatus,
   SynchronizationJob,
+  IntegrationSynchronizationJob,
 } from '../framework/synchronization';
 
 export function generateSynchronizationJob(): SynchronizationJob {
   return {
     id: 'test',
-    integrationJobId: 'test-job-id',
-    integrationInstanceId: 'test-instance-id',
     status: SynchronizationJobStatus.AWAITING_UPLOADS,
     startTimestamp: Date.now(),
     numEntitiesUploaded: 0,
@@ -18,5 +17,13 @@ export function generateSynchronizationJob(): SynchronizationJob {
     numRelationshipsCreated: 0,
     numRelationshipsUpdated: 0,
     numRelationshipsDeleted: 0,
+  };
+}
+
+export function generateIntegrationSynchronizationJob(): IntegrationSynchronizationJob {
+  return {
+    integrationJobId: 'test-job-id',
+    integrationInstanceId: 'test-instance-id',
+    ...generateSynchronizationJob(),
   };
 }

--- a/src/cli/commands/collect.ts
+++ b/src/cli/commands/collect.ts
@@ -3,10 +3,7 @@ import { createCommand } from 'commander';
 import * as log from '../../log';
 
 import { buildStepDependencyGraph } from '../../framework/execution/dependencyGraph';
-import {
-  executeIntegrationLocally,
-  IntegrationStepStartStates,
-} from '../../framework';
+import { executeIntegrationLocally, StepStartStates } from '../../framework';
 import { loadConfig } from '../../framework/config';
 
 // coercion function to collect multiple values for a flag
@@ -52,7 +49,7 @@ export function collect() {
         ? (ctx) => {
             const originalEnabledRecord =
               originalGetStepStartStates?.(ctx) ?? {};
-            const enabledRecord: IntegrationStepStartStates = {};
+            const enabledRecord: StepStartStates = {};
             for (const stepId of allStepIds) {
               const originalValue = originalEnabledRecord[stepId] ?? {};
               if (stepsToRun.includes(stepId)) {

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -9,7 +9,7 @@ import {
 import { loadConfig } from '../../framework/config';
 import { createIntegrationLogger } from '../../framework/execution/logger';
 import {
-  initiateSynchronization,
+  initiateIntegrationSynchronization,
   uploadCollectedData,
   finalizeSynchronization,
   abortSynchronization,
@@ -44,7 +44,7 @@ export function run() {
 
       const invocationConfig = await loadConfig();
 
-      const synchronizationContext = await initiateSynchronization({
+      const synchronizationContext = await initiateIntegrationSynchronization({
         logger,
         apiClient,
         integrationInstanceId,

--- a/src/framework/execution/jobState.ts
+++ b/src/framework/execution/jobState.ts
@@ -1,7 +1,7 @@
 import { FileSystemGraphObjectStore } from '../storage';
 import { Entity, Relationship } from '../types';
 import { IntegrationDuplicateKeyError } from './error';
-import { IntegrationStep, JobState } from './types';
+import { Step, StepExecutionContext, JobState } from './types';
 
 export class DuplicateKeyTracker {
   private readonly keySet = new Set<string>();
@@ -29,13 +29,15 @@ export class MemoryDataStore {
   }
 }
 
-export function createStepJobState({
+export function createStepJobState<
+  TStepExecutionContext extends StepExecutionContext
+>({
   step,
   duplicateKeyTracker,
   graphObjectStore,
   dataStore,
 }: {
-  step: IntegrationStep;
+  step: Step<TStepExecutionContext>;
   duplicateKeyTracker: DuplicateKeyTracker;
   graphObjectStore: FileSystemGraphObjectStore;
   dataStore: MemoryDataStore;

--- a/src/framework/execution/logger.ts
+++ b/src/framework/execution/logger.ts
@@ -235,8 +235,6 @@ function instrumentEventLogging(
 
       return createChildLogger({
         synchronizationJobId: job.id,
-        integrationJobId: job.integrationJobId,
-        integrationInstanceId: job.integrationInstanceId,
       });
     },
 

--- a/src/framework/execution/step.ts
+++ b/src/framework/execution/step.ts
@@ -5,35 +5,41 @@ import {
   executeStepDependencyGraph,
 } from './dependencyGraph';
 import {
-  IntegrationExecutionContext,
+  ExecutionContext,
   IntegrationStep,
+  Step,
   IntegrationStepResult,
   IntegrationStepResultStatus,
-  IntegrationStepStartStates,
+  IntegrationExecutionContext,
+  StepStartStates,
   PartialDatasets,
 } from './types';
 
-export async function executeSteps(
+export async function executeIntegrationSteps(
   context: IntegrationExecutionContext,
   steps: IntegrationStep[],
-  stepStartStates: IntegrationStepStartStates,
+  stepStartStates: StepStartStates,
 ): Promise<IntegrationStepResult[]> {
   const stepGraph = buildStepDependencyGraph(steps);
   return executeStepDependencyGraph(context, stepGraph, stepStartStates);
 }
 
-export function getDefaultStepStartStates(
-  steps: IntegrationStep[],
-): IntegrationStepStartStates {
-  return steps.reduce(
-    (states: IntegrationStepStartStates, step: IntegrationStep) => {
-      states[step.id] = {
-        disabled: false,
-      };
-      return states;
-    },
-    {},
-  );
+export async function executeSteps(
+  context: ExecutionContext,
+  steps: Step[],
+  stepStartStates: StepStartStates,
+): Promise<IntegrationStepResult[]> {
+  const stepGraph = buildStepDependencyGraph(steps);
+  return executeStepDependencyGraph(context, stepGraph, stepStartStates);
+}
+
+export function getDefaultStepStartStates(steps: Step[]): StepStartStates {
+  return steps.reduce((states: StepStartStates, step: Step) => {
+    states[step.id] = {
+      disabled: false,
+    };
+    return states;
+  }, {});
 }
 
 export function determinePartialDatasetsFromStepExecutionResults(

--- a/src/framework/execution/types/context.ts
+++ b/src/framework/execution/types/context.ts
@@ -2,15 +2,22 @@ import { IntegrationInstance, IntegrationInstanceConfig } from './instance';
 import { JobState } from './jobState';
 import { IntegrationLogger } from './logger';
 
+export interface ExecutionContext {
+  logger: IntegrationLogger<StepExecutionContext>;
+}
+
 /**
  * @param TConfig the integration specific type of the `instance.config`
  * property
  */
 export interface IntegrationExecutionContext<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
-> {
+> extends ExecutionContext {
   instance: IntegrationInstance<TConfig>;
-  logger: IntegrationLogger;
+}
+
+export interface StepExecutionContext extends ExecutionContext {
+  jobState: JobState;
 }
 
 /**
@@ -19,6 +26,4 @@ export interface IntegrationExecutionContext<
  */
 export interface IntegrationStepExecutionContext<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
-> extends IntegrationExecutionContext<TConfig> {
-  jobState: JobState;
-}
+> extends IntegrationExecutionContext<TConfig>, StepExecutionContext {}

--- a/src/framework/execution/types/logger.ts
+++ b/src/framework/execution/types/logger.ts
@@ -1,4 +1,4 @@
-import { IntegrationStep } from './step';
+import { Step, StepExecutionContext } from './';
 import {
   SynchronizationJobContext,
   SynchronizationJob,
@@ -8,17 +8,21 @@ interface LogFunction {
   (...args: any[]): boolean | void;
 }
 
-interface ChildLogFunction {
-  (options: object): IntegrationLogger;
+interface ChildLogFunction<TStepExecutionContext extends StepExecutionContext> {
+  (options: object): IntegrationLogger<TStepExecutionContext>;
 }
 
-type StepLogFunction = (step: IntegrationStep) => void;
-type StepLogFunctionWithError = (step: IntegrationStep, err: Error) => void;
+type StepLogFunction<TStepExecutionContext extends StepExecutionContext> = (
+  step: Step<TStepExecutionContext>,
+) => void;
+type StepLogFunctionWithError<
+  TStepExecutionContext extends StepExecutionContext
+> = (step: Step<TStepExecutionContext>, err: Error) => void;
 type SynchronizationLogFunction = (job: SynchronizationJob) => void;
 type ValidationLogFunction = (err: Error) => void;
 type IsHandledErrorFunction = (err: Error) => boolean;
 
-interface BaseLogger {
+interface BaseLogger<TStepExecutionContext extends StepExecutionContext> {
   // traditional functions for regular logging
   trace: LogFunction;
   debug: LogFunction;
@@ -26,7 +30,7 @@ interface BaseLogger {
   warn: LogFunction;
   error: LogFunction;
   fatal: LogFunction;
-  child: ChildLogFunction;
+  child: ChildLogFunction<TStepExecutionContext>;
 }
 
 export type LoggerSynchronizationJobContext = Pick<
@@ -34,17 +38,19 @@ export type LoggerSynchronizationJobContext = Pick<
   'apiClient' | 'job'
 >;
 
-export interface IntegrationLogger extends BaseLogger {
+export interface IntegrationLogger<
+  TStepExecutionContext extends StepExecutionContext
+> extends BaseLogger {
   registerSynchronizationJobContext: (
     context: LoggerSynchronizationJobContext,
-  ) => IntegrationLogger;
+  ) => IntegrationLogger<TStepExecutionContext>;
 
   isHandledError: IsHandledErrorFunction;
 
   // Special log functions used to publish events to j1
-  stepStart: StepLogFunction;
-  stepSuccess: StepLogFunction;
-  stepFailure: StepLogFunctionWithError;
+  stepStart: StepLogFunction<TStepExecutionContext>;
+  stepSuccess: StepLogFunction<TStepExecutionContext>;
+  stepFailure: StepLogFunctionWithError<TStepExecutionContext>;
   synchronizationUploadStart: SynchronizationLogFunction;
   synchronizationUploadEnd: SynchronizationLogFunction;
   validationFailure: ValidationLogFunction;

--- a/src/framework/execution/types/step.ts
+++ b/src/framework/execution/types/step.ts
@@ -1,10 +1,11 @@
 import {
   IntegrationExecutionContext,
   IntegrationStepExecutionContext,
+  StepExecutionContext,
 } from './context';
 import { IntegrationInstanceConfig } from './instance';
 
-export interface IntegrationStepStartState {
+export interface StepStartState {
   /**
    * Indicates the step is disabled and should not be
    * executed by the state machine.
@@ -12,20 +13,20 @@ export interface IntegrationStepStartState {
   disabled: boolean;
 }
 
-export type IntegrationStepStartStates = Record<
-  string,
-  IntegrationStepStartState
->;
+export type StepStartStates = Record<string, StepStartState>;
 
 export type GetStepStartStatesFunction<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
-> = (
-  context: IntegrationExecutionContext<TConfig>,
-) => IntegrationStepStartStates;
+> = (context: IntegrationExecutionContext<TConfig>) => StepStartStates;
 
-export type StepExecutionHandlerFunction<
+export type ExecutionHandlerFunction<T extends StepExecutionContext> = (
+  context: T,
+) => Promise<void> | void;
+
+export type IntegrationStepExecutionHandlerFunction<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
-> = (context: IntegrationStepExecutionContext<TConfig>) => Promise<void> | void;
+> = ExecutionHandlerFunction<IntegrationStepExecutionContext<TConfig>>;
+// > = (context: IntegrationStepExecutionContext<TConfig>) => Promise<void> | void;
 
 export enum IntegrationStepResultStatus {
   SUCCESS = 'success',
@@ -35,20 +36,30 @@ export enum IntegrationStepResultStatus {
   PENDING_EVALUATION = 'pending_evaluation',
 }
 
-export type IntegrationStep<
-  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
-> = IntegrationStepMetadata & {
-  /**
-   * Function that runs to perform the stpe that
-   */
-  executionHandler: StepExecutionHandlerFunction<TConfig>;
+export type Step<
+  TStepExecutionContext extends StepExecutionContext
+> = StepMetadata & {
+  executionHandler: ExecutionHandlerFunction<TStepExecutionContext>;
 };
 
-export type IntegrationStepResult = IntegrationStepMetadata & {
+export type IntegrationStep<
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+> = StepMetadata & Step<IntegrationStepExecutionContext<TConfig>> & {};
+
+// export type IntegrationStep<
+//   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+// > = StepMetadata & {
+//   /**
+//    * Function that runs to perform the stpe that
+//    */
+//   executionHandler: IntegrationStepExecutionHandlerFunction<TConfig>;
+// };
+
+export type IntegrationStepResult = StepMetadata & {
   status: IntegrationStepResultStatus;
 };
 
-interface IntegrationStepMetadata {
+interface StepMetadata {
   /*
    * Identifier used to reference and track steps
    */

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -7,6 +7,6 @@ export * from './types';
 
 export { loadConfig } from './config';
 
-export { createApiClient } from './api';
+export { createApiClient, ApiClient } from './api';
 
 export * from './synchronization';

--- a/src/framework/synchronization/__tests__/index.test.ts
+++ b/src/framework/synchronization/__tests__/index.test.ts
@@ -4,7 +4,7 @@ import noop from 'lodash/noop';
 
 import {
   SynchronizationJobStatus,
-  initiateSynchronization,
+  initiateIntegrationSynchronization,
   uploadCollectedData,
   finalizeSynchronization,
   synchronizeCollectedData,
@@ -27,7 +27,7 @@ afterEach(() => {
   restoreProjectStructure();
 });
 
-describe('initiateSynchronization', () => {
+describe('initiateIntegrationSynchronization', () => {
   test('hits synchronization job api to start a new job', async () => {
     const job = generateSynchronizationJob();
 
@@ -39,7 +39,9 @@ describe('initiateSynchronization', () => {
       },
     });
 
-    const synchronizationContext = await initiateSynchronization(context);
+    const synchronizationContext = await initiateIntegrationSynchronization(
+      context,
+    );
 
     expect(synchronizationContext.job).toEqual(job);
 
@@ -66,7 +68,9 @@ describe('initiateSynchronization', () => {
       'registerSynchronizationJobContext',
     );
 
-    const synchronizationContext = await initiateSynchronization(context);
+    const synchronizationContext = await initiateIntegrationSynchronization(
+      context,
+    );
 
     expect(registerSynchronizationJobContextSpy).toHaveBeenCalledTimes(1);
     expect(registerSynchronizationJobContextSpy).toHaveBeenCalledWith({
@@ -93,7 +97,7 @@ describe('initiateSynchronization', () => {
       },
     });
 
-    await expect(initiateSynchronization(context)).rejects.toThrow(
+    await expect(initiateIntegrationSynchronization(context)).rejects.toThrow(
       /instance not found/,
     );
     expect(postSpy).toHaveBeenCalledTimes(1);

--- a/src/framework/synchronization/index.ts
+++ b/src/framework/synchronization/index.ts
@@ -4,7 +4,7 @@ import pMap from 'p-map';
 
 import { ApiClient } from '../api';
 
-import { SynchronizationJob } from './types';
+import { SynchronizationJob, IntegrationSynchronizationJob } from './types';
 import {
   ExecuteIntegrationResult,
   PartialDatasets,
@@ -36,7 +36,7 @@ interface SynchronizeInput {
 export async function synchronizeCollectedData(
   input: SynchronizeInput,
 ): Promise<SynchronizationJob> {
-  const jobContext = await initiateSynchronization(input);
+  const jobContext = await initiateIntegrationSynchronization(input);
 
   try {
     await uploadCollectedData(jobContext);
@@ -58,21 +58,21 @@ export async function synchronizeCollectedData(
 
 export interface SynchronizationJobContext {
   apiClient: ApiClient;
-  job: SynchronizationJob;
+  job: IntegrationSynchronizationJob;
   logger: IntegrationLogger;
 }
 
 /**
  * Initializes a synchronization job
  */
-export async function initiateSynchronization({
+export async function initiateIntegrationSynchronization({
   logger,
   apiClient,
   integrationInstanceId,
 }: SynchronizeInput): Promise<SynchronizationJobContext> {
   logger.info('Initiating synchronization job...');
 
-  let job: SynchronizationJob;
+  let job: IntegrationSynchronizationJob;
   try {
     const response = await apiClient.post('/persister/synchronization/jobs', {
       source: 'integration-managed',

--- a/src/framework/synchronization/types.ts
+++ b/src/framework/synchronization/types.ts
@@ -11,8 +11,8 @@ export enum SynchronizationJobStatus {
 
 export interface SynchronizationJob {
   id: string;
-  integrationJobId: string;
-  integrationInstanceId: string;
+  // integrationJobId: string;
+  // integrationInstanceId: string;
   status: SynchronizationJobStatus;
   startTimestamp: number;
   numEntitiesUploaded: number;
@@ -23,6 +23,11 @@ export interface SynchronizationJob {
   numRelationshipsCreated: number;
   numRelationshipsUpdated: number;
   numRelationshipsDeleted: number;
+}
+
+export interface IntegrationSynchronizationJob extends SynchronizationJob {
+  integrationJobId: string;
+  integrationInstanceId: string;
 }
 
 export interface SynchronizatoinApiErrorResponse {


### PR DESCRIPTION
A user may want to execute some steps but not tie the execution to a specific integration instance, but rather just follow the same patterns as the managed integrations.