### PR TITLE
Initial changes to decompose integration execution functionality

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -45,7 +45,7 @@ export const invocationConfig: IntegrationInvocationConfig = {
 
   getStepStartStates(
     executionContext: IntegrationExecutionContext,
-  ): IntegrationStepStartStates {
+  ): StepStartStates {
     const { config } = executionContext.instance;
 
     const notDisabled = { disabled: false };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/integration-sdk",
-  "version": "2.1.4",
+  "version": "3.0.0",
   "description": "The SDK for developing JupiterOne integrations",
   "main": "src/framework/index.js",
   "types": "src/framework/index.d.ts",

--- a/src/__tests__/log.test.ts
+++ b/src/__tests__/log.test.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import noop from 'lodash/noop';
 import * as log from '../log';
 
-import { IntegrationStepResultStatus } from '../framework';
+import { StepResultStatus } from '../framework';
 
 test("displays extraneous and undeclared types from a step's result", () => {
   const consoleSpy = jest.spyOn(console, 'log').mockImplementation(noop);
@@ -14,7 +14,7 @@ test("displays extraneous and undeclared types from a step's result", () => {
         name: 'Step A',
         declaredTypes: ['test_a', 'test_b'],
         encounteredTypes: ['test_a', 'test_c'],
-        status: IntegrationStepResultStatus.SUCCESS,
+        status: StepResultStatus.SUCCESS,
       },
     ],
     metadata: {

--- a/src/cli/__tests__/cli-run.test.ts
+++ b/src/cli/__tests__/cli-run.test.ts
@@ -12,7 +12,7 @@ import {
 } from './util/synchronization';
 
 import { SynchronizationJobStatus } from '../../framework/synchronization';
-import { IntegrationStepResultStatus } from '../../framework';
+import { StepResultStatus } from '../../framework';
 
 import * as log from '../../log';
 
@@ -88,14 +88,14 @@ test('executes integration and performs upload', async () => {
         name: 'Fetch Accounts',
         declaredTypes: ['my_account'],
         encounteredTypes: ['my_account'],
-        status: IntegrationStepResultStatus.SUCCESS,
+        status: StepResultStatus.SUCCESS,
       },
       {
         id: 'fetch-users',
         name: 'Fetch Users',
         declaredTypes: ['my_user', 'my_account_has_user'],
         encounteredTypes: ['my_user', 'my_account_has_user'],
-        status: IntegrationStepResultStatus.SUCCESS,
+        status: StepResultStatus.SUCCESS,
       },
     ],
     metadata: {

--- a/src/cli/__tests__/cli.test.ts
+++ b/src/cli/__tests__/cli.test.ts
@@ -3,7 +3,7 @@ import { createCli } from '../index';
 import { loadProjectStructure } from '../../__tests__/loadProjectStructure';
 import * as log from '../../log';
 
-import { IntegrationStepResultStatus } from '../../framework/execution';
+import { StepResultStatus } from '../../framework/execution';
 import * as nodeFs from 'fs';
 const fs = nodeFs.promises;
 
@@ -29,7 +29,7 @@ describe('collect', () => {
           name: 'Fetch Accounts',
           declaredTypes: ['my_account'],
           encounteredTypes: [],
-          status: IntegrationStepResultStatus.SUCCESS,
+          status: StepResultStatus.SUCCESS,
         },
         {
           id: 'fetch-groups',
@@ -37,14 +37,14 @@ describe('collect', () => {
           name: 'Fetch Groups',
           declaredTypes: ['my_groups'],
           encounteredTypes: [],
-          status: IntegrationStepResultStatus.SUCCESS,
+          status: StepResultStatus.SUCCESS,
         },
         {
           id: 'fetch-users',
           name: 'Fetch Users',
           declaredTypes: ['my_user'],
           encounteredTypes: [],
-          status: IntegrationStepResultStatus.SUCCESS,
+          status: StepResultStatus.SUCCESS,
         },
       ],
       metadata: {
@@ -73,7 +73,7 @@ describe('collect', () => {
             name: 'Fetch Accounts',
             declaredTypes: ['my_account'],
             encounteredTypes: [],
-            status: IntegrationStepResultStatus.DISABLED,
+            status: StepResultStatus.DISABLED,
           },
           {
             id: 'fetch-groups',
@@ -81,14 +81,14 @@ describe('collect', () => {
             name: 'Fetch Groups',
             declaredTypes: ['my_groups'],
             encounteredTypes: [],
-            status: IntegrationStepResultStatus.DISABLED,
+            status: StepResultStatus.DISABLED,
           },
           {
             id: 'fetch-users',
             name: 'Fetch Users',
             declaredTypes: ['my_user'],
             encounteredTypes: [],
-            status: IntegrationStepResultStatus.SUCCESS,
+            status: StepResultStatus.SUCCESS,
           },
         ],
         metadata: {
@@ -118,7 +118,7 @@ describe('collect', () => {
             name: 'Fetch Accounts',
             declaredTypes: ['my_account'],
             encounteredTypes: [],
-            status: IntegrationStepResultStatus.SUCCESS,
+            status: StepResultStatus.SUCCESS,
           },
           {
             id: 'fetch-groups',
@@ -126,14 +126,14 @@ describe('collect', () => {
             name: 'Fetch Groups',
             declaredTypes: ['my_groups'],
             encounteredTypes: [],
-            status: IntegrationStepResultStatus.DISABLED,
+            status: StepResultStatus.DISABLED,
           },
           {
             id: 'fetch-users',
             name: 'Fetch Users',
             declaredTypes: ['my_user'],
             encounteredTypes: [],
-            status: IntegrationStepResultStatus.SUCCESS,
+            status: StepResultStatus.SUCCESS,
           },
         ],
         metadata: {
@@ -165,7 +165,7 @@ describe('collect', () => {
             name: 'Fetch Accounts',
             declaredTypes: ['my_account'],
             encounteredTypes: [],
-            status: IntegrationStepResultStatus.SUCCESS,
+            status: StepResultStatus.SUCCESS,
           },
           {
             id: 'fetch-groups',
@@ -173,14 +173,14 @@ describe('collect', () => {
             name: 'Fetch Groups',
             declaredTypes: ['my_groups'],
             encounteredTypes: [],
-            status: IntegrationStepResultStatus.DISABLED,
+            status: StepResultStatus.DISABLED,
           },
           {
             id: 'fetch-users',
             name: 'Fetch Users',
             declaredTypes: ['my_user'],
             encounteredTypes: [],
-            status: IntegrationStepResultStatus.SUCCESS,
+            status: StepResultStatus.SUCCESS,
           },
         ],
         metadata: {
@@ -209,7 +209,7 @@ describe('collect', () => {
             name: 'Fetch Accounts',
             declaredTypes: ['my_account'],
             encounteredTypes: [],
-            status: IntegrationStepResultStatus.SUCCESS,
+            status: StepResultStatus.SUCCESS,
           },
           {
             id: 'fetch-groups',
@@ -217,14 +217,14 @@ describe('collect', () => {
             name: 'Fetch Groups',
             declaredTypes: ['my_groups'],
             encounteredTypes: [],
-            status: IntegrationStepResultStatus.SUCCESS,
+            status: StepResultStatus.SUCCESS,
           },
           {
             id: 'fetch-users',
             name: 'Fetch Users',
             declaredTypes: ['my_user'],
             encounteredTypes: [],
-            status: IntegrationStepResultStatus.DISABLED,
+            status: StepResultStatus.DISABLED,
           },
         ],
         metadata: {

--- a/src/cli/commands/collect.ts
+++ b/src/cli/commands/collect.ts
@@ -5,7 +5,10 @@ import * as log from '../../log';
 import { buildStepDependencyGraph } from '../../framework/execution/dependencyGraph';
 import {
   executeIntegrationLocally,
-  IntegrationStepStartStates,
+  StepStartStates,
+  InvocationConfig,
+  ExecutionContext,
+  StepExecutionContext,
 } from '../../framework';
 import { loadConfig } from '../../framework/config';
 
@@ -14,6 +17,61 @@ const collecter = (value: string, arr: string[]) => {
   arr.push(...value.split(','));
   return arr;
 };
+
+export interface CollectOptions {
+  step?: string[];
+}
+
+export function prepareLocalStepCollection<
+  TExecutionContext extends ExecutionContext,
+  TStepExecutionContext extends StepExecutionContext
+>(
+  config: InvocationConfig<TExecutionContext, TStepExecutionContext>,
+  { step = [] }: CollectOptions = {},
+) {
+  const allStepIds = config.integrationSteps.map((step) => step.id);
+
+  const stepsToRun: string[] = step.filter(
+    (step: string | undefined | null) => step !== undefined && step !== null,
+  );
+
+  // build out the dependecy graph so we can
+  // enable the dependencies of the steps
+  // we want to run.
+  const depGraph = buildStepDependencyGraph(config.integrationSteps);
+  const dependentSteps: string[] = [];
+  for (const step of stepsToRun) {
+    const dependencies = depGraph.dependenciesOf(step);
+    dependentSteps.push(...dependencies);
+  }
+
+  stepsToRun.push(...dependentSteps);
+  const originalGetStepStartStates = config.getStepStartStates;
+
+  config.getStepStartStates = stepsToRun.length
+    ? (ctx) => {
+        const originalEnabledRecord = originalGetStepStartStates?.(ctx) ?? {};
+        const enabledRecord: StepStartStates = {};
+        for (const stepId of allStepIds) {
+          const originalValue = originalEnabledRecord[stepId] ?? {};
+          if (stepsToRun.includes(stepId)) {
+            enabledRecord[stepId] = {
+              ...originalValue,
+              disabled: false,
+            };
+          } else {
+            enabledRecord[stepId] = {
+              ...originalValue,
+              disabled: true,
+            };
+          }
+        }
+        return enabledRecord;
+      }
+    : originalGetStepStartStates;
+
+  return config;
+}
 
 export function collect() {
   return createCommand('collect')
@@ -28,50 +86,8 @@ export function collect() {
     )
     .action(async (options) => {
       const config = await loadConfig();
-
-      const allStepIds = config.integrationSteps.map((step) => step.id);
-
-      const stepsToRun: string[] = (options.step ? options.step : []).filter(
-        (step: string | undefined | null) =>
-          step !== undefined && step !== null,
-      );
-      // build out the dependecy graph so we can
-      // enable the dependencies of the steps
-      // we want to run.
-      const depGraph = buildStepDependencyGraph(config.integrationSteps);
-      const dependentSteps: string[] = [];
-      for (const step of stepsToRun) {
-        const dependencies = depGraph.dependenciesOf(step);
-        dependentSteps.push(...dependencies);
-      }
-      stepsToRun.push(...dependentSteps);
-
-      const originalGetStepStartStates = config.getStepStartStates;
-
-      config.getStepStartStates = stepsToRun.length
-        ? (ctx) => {
-            const originalEnabledRecord =
-              originalGetStepStartStates?.(ctx) ?? {};
-            const enabledRecord: IntegrationStepStartStates = {};
-            for (const stepId of allStepIds) {
-              const originalValue = originalEnabledRecord[stepId] ?? {};
-              if (stepsToRun.includes(stepId)) {
-                enabledRecord[stepId] = {
-                  ...originalValue,
-                  disabled: false,
-                };
-              } else {
-                enabledRecord[stepId] = {
-                  ...originalValue,
-                  disabled: true,
-                };
-              }
-            }
-            return enabledRecord;
-          }
-        : originalGetStepStartStates;
+      prepareLocalStepCollection(config, options);
       log.info('\nConfiguration loaded! Running integration...\n');
-
       const results = await executeIntegrationLocally(config);
       log.displayExecutionResults(results);
     });

--- a/src/framework/config.ts
+++ b/src/framework/config.ts
@@ -4,11 +4,12 @@ import path from 'path';
 
 import { IntegrationError } from '../errors';
 import {
+  ExecutionContext,
   GetStepStartStatesFunction,
   IntegrationInstanceConfigFieldMap,
   IntegrationInvocationConfig,
   IntegrationStep,
-  InvocationValidationFunction,
+  IntegrationInvocationValidationFunction,
 } from '../framework/execution';
 import * as log from '../log';
 
@@ -101,7 +102,7 @@ export function loadInstanceConfigFields(
  */
 export function loadValidateInvocationFunction(
   projectSourceDirectory: string = path.join(process.cwd(), 'src'),
-): InvocationValidationFunction | undefined {
+): IntegrationInvocationValidationFunction | undefined {
   return loadModuleContent(
     path.resolve(projectSourceDirectory, 'validateInvocation'),
   );
@@ -110,10 +111,10 @@ export function loadValidateInvocationFunction(
 /**
  * Loads getStepStartStates function from ./src/getStepStartStates.(t|j)s
  */
-export function loadGetStepStartStatesFunction(
+export function loadGetStepStartStatesFunction<T extends ExecutionContext>(
   projectSourceDirectory: string = path.join(process.cwd(), 'src'),
 ) {
-  return loadModuleContent<GetStepStartStatesFunction>(
+  return loadModuleContent<GetStepStartStatesFunction<T>>(
     path.resolve(projectSourceDirectory, 'getStepStartStates'),
   );
 }

--- a/src/framework/execution/__tests__/dependencyGraph.test.ts
+++ b/src/framework/execution/__tests__/dependencyGraph.test.ts
@@ -19,7 +19,7 @@ import {
   IntegrationLogger,
   IntegrationStep,
   IntegrationStepExecutionContext,
-  IntegrationStepResultStatus,
+  StepResultStatus,
   JobState,
 } from '../types';
 
@@ -253,7 +253,7 @@ describe('executeStepDependencyGraph', () => {
         name: 'a',
         declaredTypes: ['my_type_a'],
         encounteredTypes: ['my_type_b'],
-        status: IntegrationStepResultStatus.SUCCESS,
+        status: StepResultStatus.SUCCESS,
       },
     ]);
 
@@ -544,7 +544,7 @@ describe('executeStepDependencyGraph', () => {
         name: 'a',
         declaredTypes: [],
         encounteredTypes: [],
-        status: IntegrationStepResultStatus.SUCCESS,
+        status: StepResultStatus.SUCCESS,
       },
       {
         id: 'b',
@@ -552,7 +552,7 @@ describe('executeStepDependencyGraph', () => {
         declaredTypes: [],
         encounteredTypes: [],
         dependsOn: ['a'],
-        status: IntegrationStepResultStatus.FAILURE,
+        status: StepResultStatus.FAILURE,
       },
       {
         id: 'c',
@@ -560,8 +560,7 @@ describe('executeStepDependencyGraph', () => {
         declaredTypes: [],
         encounteredTypes: [],
         dependsOn: ['b'],
-        status:
-          IntegrationStepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE,
+        status: StepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE,
       },
     ]);
 
@@ -668,7 +667,7 @@ describe('executeStepDependencyGraph', () => {
         name: 'a',
         declaredTypes: [],
         encounteredTypes: [],
-        status: IntegrationStepResultStatus.FAILURE,
+        status: StepResultStatus.FAILURE,
       },
       {
         id: 'b',
@@ -676,8 +675,7 @@ describe('executeStepDependencyGraph', () => {
         declaredTypes: [],
         encounteredTypes: [],
         dependsOn: ['a'],
-        status:
-          IntegrationStepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE,
+        status: StepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE,
       },
       {
         id: 'c',
@@ -685,8 +683,7 @@ describe('executeStepDependencyGraph', () => {
         declaredTypes: [],
         encounteredTypes: [],
         dependsOn: ['b'],
-        status:
-          IntegrationStepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE,
+        status: StepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE,
       },
     ]);
 
@@ -1005,7 +1002,7 @@ describe('executeStepDependencyGraph', () => {
         name: 'a',
         declaredTypes: [],
         encounteredTypes: [],
-        status: IntegrationStepResultStatus.DISABLED,
+        status: StepResultStatus.DISABLED,
       },
     ]);
   });
@@ -1081,14 +1078,14 @@ describe('executeStepDependencyGraph', () => {
           name: 'a',
           declaredTypes: [],
           encounteredTypes: [],
-          status: IntegrationStepResultStatus.SUCCESS,
+          status: StepResultStatus.SUCCESS,
         },
         {
           id: 'b',
           name: 'b',
           declaredTypes: [],
           encounteredTypes: [],
-          status: IntegrationStepResultStatus.DISABLED,
+          status: StepResultStatus.DISABLED,
         },
         {
           id: 'c',
@@ -1096,7 +1093,7 @@ describe('executeStepDependencyGraph', () => {
           declaredTypes: [],
           encounteredTypes: [],
           dependsOn: ['a'],
-          status: IntegrationStepResultStatus.SUCCESS,
+          status: StepResultStatus.SUCCESS,
         },
         {
           id: 'd',
@@ -1104,14 +1101,14 @@ describe('executeStepDependencyGraph', () => {
           declaredTypes: [],
           encounteredTypes: [],
           dependsOn: ['b', 'c', 'e'],
-          status: IntegrationStepResultStatus.DISABLED,
+          status: StepResultStatus.DISABLED,
         },
         {
           id: 'e',
           name: 'e',
           declaredTypes: [],
           encounteredTypes: [],
-          status: IntegrationStepResultStatus.SUCCESS,
+          status: StepResultStatus.SUCCESS,
         },
       ]),
     );

--- a/src/framework/execution/__tests__/executeIntegration.test.ts
+++ b/src/framework/execution/__tests__/executeIntegration.test.ts
@@ -15,8 +15,8 @@ import {
   IntegrationInstance,
   IntegrationInvocationConfig,
   IntegrationLogger,
-  IntegrationStepResultStatus,
-  InvocationValidationFunction,
+  StepResultStatus,
+  IntegrationInvocationValidationFunction,
 } from '../types';
 import { IntegrationValidationError } from '../error';
 
@@ -28,7 +28,7 @@ afterEach(() => {
 });
 
 describe('executeIntegrationInstance', () => {
-  let validate: InvocationValidationFunction;
+  let validate: IntegrationInvocationValidationFunction;
   let instance: IntegrationInstance;
   let invocationConfig: IntegrationInvocationConfig;
   let logger: IntegrationLogger;
@@ -97,7 +97,7 @@ describe('executeIntegrationInstance', () => {
           name: 'My awesome step',
           declaredTypes: ['test'],
           encounteredTypes: [],
-          status: IntegrationStepResultStatus.SUCCESS,
+          status: StepResultStatus.SUCCESS,
         },
       ],
       metadata: {
@@ -130,7 +130,7 @@ describe('executeIntegrationInstance', () => {
           name: 'My awesome step',
           declaredTypes: ['test'],
           encounteredTypes: [],
-          status: IntegrationStepResultStatus.FAILURE,
+          status: StepResultStatus.FAILURE,
         },
       ],
       metadata: {
@@ -170,7 +170,7 @@ describe('executeIntegrationInstance', () => {
           name: 'My awesome step',
           declaredTypes: ['test_a'],
           encounteredTypes: [],
-          status: IntegrationStepResultStatus.FAILURE,
+          status: StepResultStatus.FAILURE,
         },
         {
           id: 'my-step-b',
@@ -178,8 +178,7 @@ describe('executeIntegrationInstance', () => {
           declaredTypes: ['test_b'],
           encounteredTypes: [],
           dependsOn: ['my-step-a'],
-          status:
-            IntegrationStepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE,
+          status: StepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE,
         },
       ],
       metadata: {
@@ -222,14 +221,14 @@ describe('executeIntegrationInstance', () => {
           name: 'My awesome step',
           declaredTypes: ['test_a'],
           encounteredTypes: [],
-          status: IntegrationStepResultStatus.FAILURE,
+          status: StepResultStatus.FAILURE,
         },
         {
           id: 'my-step-b',
           name: 'My awesome step',
           declaredTypes: ['test_b'],
           encounteredTypes: [],
-          status: IntegrationStepResultStatus.DISABLED,
+          status: StepResultStatus.DISABLED,
         },
       ],
       metadata: {
@@ -318,14 +317,14 @@ describe('executeIntegrationInstance', () => {
           name: 'My awesome step',
           declaredTypes: ['test'],
           encounteredTypes: [],
-          status: IntegrationStepResultStatus.SUCCESS,
+          status: StepResultStatus.SUCCESS,
         },
         {
           id: 'my-step-2',
           name: 'My awesome second step',
           declaredTypes: ['test_2'],
           encounteredTypes: [],
-          status: IntegrationStepResultStatus.FAILURE,
+          status: StepResultStatus.FAILURE,
         },
       ],
       metadata: {

--- a/src/framework/execution/__tests__/logger.test.ts
+++ b/src/framework/execution/__tests__/logger.test.ts
@@ -140,7 +140,12 @@ describe('createIntegrationLogger', () => {
       invocationConfig,
       serializers: {},
     });
-    expect(addSerializers).toHaveBeenLastCalledWith({});
+
+    expect(addSerializers).toHaveBeenCalledTimes(1);
+    expect(addSerializers).toHaveBeenCalledWith({
+      integrationInstanceConfig: expect.any(Function),
+      instance: expect.any(Function),
+    });
   });
 
   describe('integrationInstanceConfig serializer', () => {

--- a/src/framework/execution/__tests__/validation.test.ts
+++ b/src/framework/execution/__tests__/validation.test.ts
@@ -1,10 +1,10 @@
-import { IntegrationStep, IntegrationStepStartStates } from '../types';
+import { IntegrationStep, StepStartStates } from '../types';
 
 import { validateStepStartStates } from '../validation';
 
 describe('validateStepStartStates', () => {
   test('throws error if unknown steps are found in start states', () => {
-    const states: IntegrationStepStartStates = {
+    const states: StepStartStates = {
       a: {
         disabled: false,
       },
@@ -30,7 +30,7 @@ describe('validateStepStartStates', () => {
   });
 
   test('throws error when steps are not accounted for in start states', () => {
-    const states: IntegrationStepStartStates = {
+    const states: StepStartStates = {
       a: {
         disabled: false,
       },
@@ -62,7 +62,7 @@ describe('validateStepStartStates', () => {
   });
 
   test('passes if all steps are accounted for', () => {
-    const states: IntegrationStepStartStates = {
+    const states: StepStartStates = {
       a: {
         disabled: false,
       },

--- a/src/framework/execution/error.ts
+++ b/src/framework/execution/error.ts
@@ -26,7 +26,7 @@ export class IntegrationConfigLoadError extends IntegrationError {
   }
 }
 
-export class IntegrationStepStartStateUnknownStepIdsError extends IntegrationError {
+export class StepStartStateUnknownStepIdsError extends IntegrationError {
   constructor(message: string) {
     super({
       code: 'UNKNOWN_STEP_ID_SPECIFIED_IN_START_STATE',
@@ -35,7 +35,7 @@ export class IntegrationStepStartStateUnknownStepIdsError extends IntegrationErr
   }
 }
 
-export class IntegrationUnaccountedStepStartStatesError extends IntegrationError {
+export class UnaccountedStepStartStatesError extends IntegrationError {
   constructor(message: string) {
     super({
       code: 'UNACCOUNTED_STEP_START_STATES',

--- a/src/framework/execution/executeIntegration.ts
+++ b/src/framework/execution/executeIntegration.ts
@@ -66,8 +66,6 @@ export async function executeIntegrationInstance(
     config,
   );
 
-  await logger.flush();
-
   return result;
 }
 
@@ -121,6 +119,8 @@ export async function executeWithContext<
     { collectionResult: summary },
     'Integration data collection has completed.',
   );
+
+  await context.logger.flush();
 
   return summary;
 }

--- a/src/framework/execution/executeIntegration.ts
+++ b/src/framework/execution/executeIntegration.ts
@@ -7,7 +7,6 @@ import {
   getDefaultStepStartStates,
 } from './step';
 import {
-  IntegrationExecutionContext,
   IntegrationInstance,
   IntegrationInvocationConfig,
   IntegrationLogger,
@@ -15,6 +14,7 @@ import {
   PartialDatasets,
   InvocationConfig,
   StepExecutionContext,
+  ExecutionContext,
 } from './types';
 
 export interface ExecuteIntegrationResult {
@@ -76,7 +76,7 @@ export async function executeIntegrationInstance(
  * using context that was provided.
  */
 export async function executeWithContext<
-  TExecutionContext extends IntegrationExecutionContext,
+  TExecutionContext extends ExecutionContext,
   TStepExecutionContext extends StepExecutionContext
 >(
   context: TExecutionContext,

--- a/src/framework/execution/executeIntegration.ts
+++ b/src/framework/execution/executeIntegration.ts
@@ -13,6 +13,8 @@ import {
   IntegrationLogger,
   IntegrationStepResult,
   PartialDatasets,
+  InvocationConfig,
+  StepExecutionContext,
 } from './types';
 
 export interface ExecuteIntegrationResult {
@@ -56,7 +58,7 @@ export async function executeIntegrationInstance(
     process.env.ENABLE_GRAPH_OBJECT_SCHEMA_VALIDATION = 'true';
   }
 
-  const result = await executeIntegration(
+  const result = await executeWithContext(
     {
       instance,
       logger,
@@ -73,9 +75,12 @@ export async function executeIntegrationInstance(
  * Executes an integration and performs actions defined by the config
  * using context that was provided.
  */
-async function executeIntegration(
-  context: IntegrationExecutionContext,
-  config: IntegrationInvocationConfig,
+export async function executeWithContext<
+  TExecutionContext extends IntegrationExecutionContext,
+  TStepExecutionContext extends StepExecutionContext
+>(
+  context: TExecutionContext,
+  config: InvocationConfig<TExecutionContext, TStepExecutionContext>,
 ): Promise<ExecuteIntegrationResult> {
   await removeStorageDirectory();
 
@@ -100,7 +105,7 @@ async function executeIntegration(
     integrationStepResults,
   );
 
-  const summary = {
+  const summary: ExecuteIntegrationResult = {
     integrationStepResults,
     metadata: {
       partialDatasets,

--- a/src/framework/execution/index.ts
+++ b/src/framework/execution/index.ts
@@ -2,4 +2,4 @@ export * from './executeIntegration';
 export * from './types';
 export * from './error';
 
-export { createIntegrationLogger } from './logger';
+export { createIntegrationLogger, createLogger } from './logger';

--- a/src/framework/execution/jobState.ts
+++ b/src/framework/execution/jobState.ts
@@ -1,7 +1,7 @@
 import { FileSystemGraphObjectStore } from '../storage';
 import { Entity, Relationship } from '../types';
 import { IntegrationDuplicateKeyError } from './error';
-import { IntegrationStep, JobState } from './types';
+import { JobState } from './types';
 
 export class DuplicateKeyTracker {
   private readonly keySet = new Set<string>();
@@ -42,13 +42,13 @@ export class MemoryDataStore {
 }
 
 export function createStepJobState({
-  step,
+  stepId,
   duplicateKeyTracker,
   typeTracker,
   graphObjectStore,
   dataStore,
 }: {
-  step: IntegrationStep;
+  stepId: string;
   duplicateKeyTracker: DuplicateKeyTracker;
   typeTracker: TypeTracker;
   graphObjectStore: FileSystemGraphObjectStore;
@@ -60,7 +60,7 @@ export function createStepJobState({
       typeTracker.registerType(e._type);
     });
 
-    return graphObjectStore.addEntities(step.id, entities);
+    return graphObjectStore.addEntities(stepId, entities);
   };
 
   const addRelationships = (relationships: Relationship[]) => {
@@ -70,7 +70,7 @@ export function createStepJobState({
       typeTracker.registerType(r._type as string);
     });
 
-    return graphObjectStore.addRelationships(step.id, relationships);
+    return graphObjectStore.addRelationships(stepId, relationships);
   };
 
   return {

--- a/src/framework/execution/logger.ts
+++ b/src/framework/execution/logger.ts
@@ -223,6 +223,10 @@ function instrumentEventLogging(
   const child = logger.child;
 
   const publishEvent = (name: string, description: string) => {
+    if (process.env.JUPITERONE_DISABLE_EVENT_LOGGING === 'true') {
+      return;
+    }
+
     if (context.synchronizationJobContext) {
       const { job, apiClient } = context.synchronizationJobContext;
 

--- a/src/framework/execution/logger.ts
+++ b/src/framework/execution/logger.ts
@@ -13,7 +13,7 @@ import {
   IntegrationInstanceConfigFieldMap,
   IntegrationInvocationConfig,
   IntegrationLogger,
-  IntegrationStep,
+  StepMetadata,
   LoggerSynchronizationJobContext,
   IntegrationLoggerFunctions,
 } from './types';
@@ -243,21 +243,21 @@ function instrumentEventLogging(
 
     isHandledError: (err: Error) => errorSet.has(err),
 
-    stepStart: (step: IntegrationStep) => {
+    stepStart: (step: StepMetadata) => {
       const name = 'step_start';
       const description = `Starting step "${step.name}"...`;
       logger.info({ step: step.id }, description);
 
       publishEvent(name, description);
     },
-    stepSuccess: (step: IntegrationStep) => {
+    stepSuccess: (step: StepMetadata) => {
       const name = 'step_end';
       const description = `Completed step "${step.name}".`;
       logger.info({ step: step.id }, description);
 
       publishEvent(name, description);
     },
-    stepFailure: (step: IntegrationStep, err: Error) => {
+    stepFailure: (step: StepMetadata, err: Error) => {
       const name = 'step_failure';
       const { errorId, description } = createErrorEventDescription(
         err,

--- a/src/framework/execution/step.ts
+++ b/src/framework/execution/step.ts
@@ -5,28 +5,32 @@ import {
   executeStepDependencyGraph,
 } from './dependencyGraph';
 import {
-  IntegrationExecutionContext,
-  IntegrationStep,
+  ExecutionContext,
   IntegrationStepResult,
-  IntegrationStepResultStatus,
-  IntegrationStepStartStates,
+  StepResultStatus,
+  StepStartStates,
   PartialDatasets,
+  Step,
+  StepExecutionContext,
 } from './types';
 
-export async function executeSteps(
-  context: IntegrationExecutionContext,
-  steps: IntegrationStep[],
-  stepStartStates: IntegrationStepStartStates,
+export async function executeSteps<
+  TExecutionContext extends ExecutionContext,
+  TStepExecutionContext extends StepExecutionContext
+>(
+  context: TExecutionContext,
+  steps: Step<TStepExecutionContext>[],
+  stepStartStates: StepStartStates,
 ): Promise<IntegrationStepResult[]> {
   const stepGraph = buildStepDependencyGraph(steps);
   return executeStepDependencyGraph(context, stepGraph, stepStartStates);
 }
 
-export function getDefaultStepStartStates(
-  steps: IntegrationStep[],
-): IntegrationStepStartStates {
+export function getDefaultStepStartStates<
+  TStepExecutionContext extends StepExecutionContext
+>(steps: Step<TStepExecutionContext>[]): StepStartStates {
   return steps.reduce(
-    (states: IntegrationStepStartStates, step: IntegrationStep) => {
+    (states: StepStartStates, step: Step<TStepExecutionContext>) => {
       states[step.id] = {
         disabled: false,
       };
@@ -42,9 +46,9 @@ export function determinePartialDatasetsFromStepExecutionResults(
   return stepResults.reduce(
     (partialDatasets: PartialDatasets, stepResult: IntegrationStepResult) => {
       if (
-        stepResult.status === IntegrationStepResultStatus.FAILURE ||
+        stepResult.status === StepResultStatus.FAILURE ||
         stepResult.status ===
-          IntegrationStepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE
+          StepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE
       ) {
         partialDatasets.types = uniq(
           partialDatasets.types.concat(stepResult.declaredTypes),

--- a/src/framework/execution/types/config.ts
+++ b/src/framework/execution/types/config.ts
@@ -1,14 +1,30 @@
 import { IntegrationInstanceConfig } from './instance';
-import { GetStepStartStatesFunction, IntegrationStep } from './step';
+import { GetStepStartStatesFunction, Step } from './step';
 import { InvocationValidationFunction } from './validation';
+import {
+  ExecutionContext,
+  IntegrationExecutionContext,
+  StepExecutionContext,
+  IntegrationStepExecutionContext,
+} from './context';
+
+export interface InvocationConfig<
+  TExecutionContext extends ExecutionContext,
+  TStepExecutionContext extends StepExecutionContext
+> {
+  validateInvocation?: InvocationValidationFunction<TExecutionContext>;
+  getStepStartStates?: GetStepStartStatesFunction<TExecutionContext>;
+  integrationSteps: Step<TStepExecutionContext>[];
+}
 
 export interface IntegrationInvocationConfig<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
-> {
+>
+  extends InvocationConfig<
+    IntegrationExecutionContext<TConfig>,
+    IntegrationStepExecutionContext<TConfig>
+  > {
   instanceConfigFields?: IntegrationInstanceConfigFieldMap;
-  validateInvocation?: InvocationValidationFunction<TConfig>;
-  getStepStartStates?: GetStepStartStatesFunction<TConfig>;
-  integrationSteps: IntegrationStep<TConfig>[];
 }
 
 export interface IntegrationInstanceConfigField {

--- a/src/framework/execution/types/context.ts
+++ b/src/framework/execution/types/context.ts
@@ -2,14 +2,7 @@ import { IntegrationInstance, IntegrationInstanceConfig } from './instance';
 import { JobState } from './jobState';
 import { IntegrationLogger } from './logger';
 
-/**
- * @param TConfig the integration specific type of the `instance.config`
- * property
- */
-export interface IntegrationExecutionContext<
-  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
-> {
-  instance: IntegrationInstance<TConfig>;
+export interface ExecutionContext {
   logger: IntegrationLogger;
 }
 
@@ -17,8 +10,20 @@ export interface IntegrationExecutionContext<
  * @param TConfig the integration specific type of the `instance.config`
  * property
  */
+export type IntegrationExecutionContext<
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+> = ExecutionContext & {
+  instance: IntegrationInstance<TConfig>;
+};
+
+export type StepExecutionContext = ExecutionContext & {
+  jobState: JobState;
+};
+
+/**
+ * @param TConfig the integration specific type of the `instance.config`
+ * property
+ */
 export interface IntegrationStepExecutionContext<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
-> extends IntegrationExecutionContext<TConfig> {
-  jobState: JobState;
-}
+> extends IntegrationExecutionContext<TConfig>, StepExecutionContext {}

--- a/src/framework/execution/types/logger.ts
+++ b/src/framework/execution/types/logger.ts
@@ -1,4 +1,4 @@
-import { IntegrationStep } from './step';
+import { StepMetadata } from './';
 import {
   SynchronizationJobContext,
   SynchronizationJob,
@@ -12,8 +12,8 @@ interface ChildLogFunction {
   (options: object): IntegrationLogger;
 }
 
-type StepLogFunction = (step: IntegrationStep) => void;
-type StepLogFunctionWithError = (step: IntegrationStep, err: Error) => void;
+type StepLogFunction = (step: StepMetadata) => void;
+type StepLogFunctionWithError = (step: StepMetadata, err: Error) => void;
 type SynchronizationLogFunction = (job: SynchronizationJob) => void;
 type ValidationLogFunction = (err: Error) => void;
 type IsHandledErrorFunction = (err: Error) => boolean;

--- a/src/framework/execution/types/step.ts
+++ b/src/framework/execution/types/step.ts
@@ -1,10 +1,11 @@
 import {
-  IntegrationExecutionContext,
+  ExecutionContext,
   IntegrationStepExecutionContext,
+  StepExecutionContext,
 } from './context';
 import { IntegrationInstanceConfig } from './instance';
 
-export interface IntegrationStepStartState {
+export interface StepStartState {
   /**
    * Indicates the step is disabled and should not be
    * executed by the state machine.
@@ -12,22 +13,21 @@ export interface IntegrationStepStartState {
   disabled: boolean;
 }
 
-export type IntegrationStepStartStates = Record<
-  string,
-  IntegrationStepStartState
->;
+export type StepStartStates = Record<string, StepStartState>;
 
-export type GetStepStartStatesFunction<
-  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
-> = (
-  context: IntegrationExecutionContext<TConfig>,
-) => IntegrationStepStartStates;
+export type GetStepStartStatesFunction<T extends ExecutionContext> = (
+  context: T,
+) => StepStartStates;
+
+export type ExecutionHandlerFunction<T extends StepExecutionContext> = (
+  context: T,
+) => Promise<void> | void;
 
 export type StepExecutionHandlerFunction<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
-> = (context: IntegrationStepExecutionContext<TConfig>) => Promise<void> | void;
+> = ExecutionHandlerFunction<IntegrationStepExecutionContext<TConfig>>;
 
-export enum IntegrationStepResultStatus {
+export enum StepResultStatus {
   SUCCESS = 'success',
   FAILURE = 'failure',
   PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE = 'partial_success_due_to_dependency_failure',
@@ -35,17 +35,15 @@ export enum IntegrationStepResultStatus {
   PENDING_EVALUATION = 'pending_evaluation',
 }
 
-export type IntegrationStep<
-  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
-> = IntegrationStepMetadata & {
+export type Step<T extends StepExecutionContext> = StepMetadata & {
   /**
    * Function that runs to perform the stpe that
    */
-  executionHandler: StepExecutionHandlerFunction<TConfig>;
+  executionHandler: ExecutionHandlerFunction<T>;
 };
 
-export type IntegrationStepResult = Omit<IntegrationStepMetadata, 'types'> & {
-  status: IntegrationStepResultStatus;
+export type IntegrationStepResult = Omit<StepMetadata, 'types'> & {
+  status: StepResultStatus;
 
   /**
    * Entity or relatioship types that were declared
@@ -58,9 +56,13 @@ export type IntegrationStepResult = Omit<IntegrationStepMetadata, 'types'> & {
    * the step's execution.
    */
   encounteredTypes: string[];
-};
+}
 
-interface IntegrationStepMetadata {
+export type IntegrationStep<
+  TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
+> = StepMetadata & Step<IntegrationStepExecutionContext<TConfig>>;
+
+export interface StepMetadata {
   /*
    * Identifier used to reference and track steps
    */

--- a/src/framework/execution/types/validation.ts
+++ b/src/framework/execution/types/validation.ts
@@ -1,6 +1,11 @@
-import { IntegrationExecutionContext } from './context';
+import { ExecutionContext, IntegrationExecutionContext } from './context';
 import { IntegrationInstanceConfig } from './instance';
 
-export type InvocationValidationFunction<
+export type InvocationValidationFunction<T extends ExecutionContext> = (
+  context: T,
+) => Promise<void> | void;
+
+// TODO: This shouldn't be necessary anymore
+export type IntegrationInvocationValidationFunction<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
-> = (context: IntegrationExecutionContext<TConfig>) => Promise<void> | void;
+> = InvocationValidationFunction<IntegrationExecutionContext<TConfig>>;

--- a/src/framework/execution/types/validation.ts
+++ b/src/framework/execution/types/validation.ts
@@ -5,7 +5,6 @@ export type InvocationValidationFunction<T extends ExecutionContext> = (
   context: T,
 ) => Promise<void> | void;
 
-// TODO: This shouldn't be necessary anymore
 export type IntegrationInvocationValidationFunction<
   TConfig extends IntegrationInstanceConfig = IntegrationInstanceConfig
 > = InvocationValidationFunction<IntegrationExecutionContext<TConfig>>;

--- a/src/framework/execution/validation.ts
+++ b/src/framework/execution/validation.ts
@@ -1,13 +1,13 @@
-import { IntegrationStep, IntegrationStepStartStates } from './types';
+import { IntegrationStep, StepStartStates } from './types';
 
 import {
-  IntegrationStepStartStateUnknownStepIdsError,
-  IntegrationUnaccountedStepStartStatesError,
+  StepStartStateUnknownStepIdsError,
+  UnaccountedStepStartStatesError,
 } from './error';
 
 export function validateStepStartStates(
   steps: IntegrationStep[],
-  stepStartStates: IntegrationStepStartStates,
+  stepStartStates: StepStartStates,
 ) {
   const stepSet = new Set<string>(steps.map((step) => step.id));
 
@@ -26,7 +26,7 @@ export function validateStepStartStates(
       .map((stepId) => `"${stepId}"`)
       .join(', ');
 
-    throw new IntegrationStepStartStateUnknownStepIdsError(
+    throw new StepStartStateUnknownStepIdsError(
       `Unknown steps found in start states: ${unknownStepIdsString}`,
     );
   }
@@ -36,7 +36,7 @@ export function validateStepStartStates(
       .map((stepId) => `"${stepId}"`)
       .join(', ');
 
-    throw new IntegrationUnaccountedStepStartStatesError(
+    throw new UnaccountedStepStartStatesError(
       `Start states not found for: ${unaccountedStepIdsString}`,
     );
   }

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -7,6 +7,6 @@ export * from './types';
 
 export { loadConfig } from './config';
 
-export { createApiClient } from './api';
+export { createApiClient, ApiClient } from './api';
 
 export * from './synchronization';

--- a/src/framework/synchronization/index.ts
+++ b/src/framework/synchronization/index.ts
@@ -20,6 +20,7 @@ import { synchronizationApiError } from './error';
 import { Entity, Relationship } from '../types';
 
 export * from './types';
+export { synchronizationApiError };
 
 const UPLOAD_BATCH_SIZE = 250;
 const UPLOAD_CONCURRENCY = 2;

--- a/src/log.ts
+++ b/src/log.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import {
   ExecuteIntegrationResult,
   IntegrationStepResult,
-  IntegrationStepResultStatus,
+  StepResultStatus,
 } from './framework/execution';
 import { SynchronizationJob } from './framework/synchronization';
 
@@ -34,7 +34,7 @@ export function displayExecutionResults(results: ExecuteIntegrationResult) {
   results.integrationStepResults.forEach((step) => {
     logStepStatus(step);
 
-    if (step.status === IntegrationStepResultStatus.SUCCESS) {
+    if (step.status === StepResultStatus.SUCCESS) {
       const { declaredTypes, encounteredTypes } = step;
 
       const declaredTypeSet = new Set(declaredTypes);
@@ -82,15 +82,15 @@ function logStepStatus(stepResult: IntegrationStepResult) {
   console.log(`${stepPrefix} ${statusText}`);
 }
 
-function getStepStatusText(status: IntegrationStepResultStatus) {
+function getStepStatusText(status: StepResultStatus) {
   switch (status) {
-    case IntegrationStepResultStatus.SUCCESS:
+    case StepResultStatus.SUCCESS:
       return chalk.green(status);
-    case IntegrationStepResultStatus.FAILURE:
+    case StepResultStatus.FAILURE:
       return chalk.red(status);
-    case IntegrationStepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE:
+    case StepResultStatus.PARTIAL_SUCCESS_DUE_TO_DEPENDENCY_FAILURE:
       return chalk.yellow(status);
-    case IntegrationStepResultStatus.DISABLED:
+    case StepResultStatus.DISABLED:
       return chalk.gray(status);
   }
 }

--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,3 +1,4 @@
 export * from './context';
 export * from './logger';
 export * from './recording';
+export * from './jobState';


### PR DESCRIPTION
A user may want to execute some steps but not tie the execution to a specific integration instance, but rather just follow the same patterns as the managed integrations.